### PR TITLE
[RFC] widen type bound for YCbCr

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -245,7 +245,7 @@ immutable YIQ{T<:FloatingPoint} <: Color{T,3}
 end
 
 @doc "`YCbCr` is the Y'CbCr color encoding often used in digital photography or video" ->
-immutable YCbCr{T<:FloatingPoint} <: Color{T,3}
+immutable YCbCr{T<:Fractional} <: Color{T,3}
     y::T
     cb::T
     cr::T
@@ -445,6 +445,7 @@ end
 
 eltype_default{C<:AbstractRGB  }(::Type{C}) = U8
 eltype_default{C<:AbstractGray }(::Type{C}) = U8
+eltype_default{C<:YCbCr        }(::Type{C}) = U8
 eltype_default{C<:Color  }(::Type{C}) = Float32
 eltype_default{P<:Colorant        }(::Type{P}) = eltype_default(color_type(P))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -83,7 +83,7 @@ end
 # Constructors
 for C in ColorTypes.parametric3
     @test eltype(C{Float32}) == Float32
-    et = (C <: AbstractRGB) ? U8 : Float32
+    et = (C <: AbstractRGB || C <: YCbCr) ? U8 : Float32
     @test eltype(C(1,0,0)) == et
     @test color_type(C(1,0,0)) == C{et}
     @test color_type(C) == C


### PR DESCRIPTION
See #10 for Context.

These are the minimal changes to make YCbCr work with Fractional as a upper bound.

I think there is a case to introduce AbstractYCbCr to furthermore allow the introduction of compact types like RGB32 and also because I had to treat YCbCr like AbstractRGB in a few places.

The only point that I see that speaks against AbstractYCbCr is that it furthermore complicates the type hierarchy and it probably needs more consideration then these changes.
