### PR TITLE
Making the @doc macro work

### DIFF
--- a/src/ColorTypes.jl
+++ b/src/ColorTypes.jl
@@ -50,7 +50,7 @@ include("show.jl")
 end # module
 
 if VERSION < v"0.4.0-dev"
-    using Docile
+    using Docile, Compat
 end
 
 @doc """


### PR DESCRIPTION
After doing a Pkg.update() I ran into problem running PyPlot, see  https://github.com/stevengj/PyPlot.jl/issues/169

I pinned it down to ColorTypes.jl 

```julia
using ColorTypes
```
```
ERROR: @doc not defined
 in include at ./boot.jl:245
 in include_from_node1 at ./loading.jl:128
 in reload_path at loading.jl:152
 in _require at loading.jl:67
 in require at loading.jl:51
while loading /home/elbeltagy/.julia/ColorTypes/src/ColorTypes.jl, in expression starting on line 86
```

This changed fixed it. 