### PR TITLE
Add support for Gray{Bool} and generalize ccolor

### DIFF
--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -1,14 +1,13 @@
 # no-op and element-type conversions, plus conversion to and from transparency
 # Colorimetry conversions are in Colors.jl
 
-convert{C<:Colorant}(::Type{C}, c::Colorant) = cconvert(ccolor(C, typeof(c)), c)
+convert{C<:Colorant}(::Type{C}, c) = cconvert(ccolor(C, typeof(c)), c)
 cconvert{C}(::Type{C}, c::C) = c
 cconvert{C}(::Type{C}, c)    = _convert(C, base_color_type(C), base_color_type(c), c)
 convert{C<:TransparentColor}(::Type{C}, c::Color, alpha) = cconvert(ccolor(C, typeof(c)), c, alpha)
 cconvert{C<:Color,T,N}(::Type{AlphaColor{C,T,N}}, c::C, alpha) = alphacolor(C)(c, alpha)
 cconvert{C<:Color,T,N}(::Type{ColorAlpha{C,T,N}}, c::C, alpha) = coloralpha(C)(c, alpha)
 cconvert{C<:TransparentColor}(::Type{C}, c::Color, alpha) =_convert(C, base_color_type(C), base_color_type(c), c, alpha)
-
 
 # Fallback definitions that print nice error messages
 _convert{C}(::Type{C}, ::Any, ::Any, c) = error("No conversion of ", c, " to ", C, " has been defined")

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -33,7 +33,7 @@ gray(c::Gray)    = c.val
 gray(c::TransparentGray) = c.val
 gray(c::Gray24)  = UFixed8(c.color & 0x000000ff, 0)
 gray(c::AGray32) = UFixed8(c.color & 0x000000ff, 0)
-gray(x::Fractional) = x
+gray(x::Union{Fractional,Bool}) = x
 
 # Extract the first, second, and third arguments as you'd
 # pass them to the constructor
@@ -139,6 +139,7 @@ any alpha-channel information).
 base_color_type{C<:Colorant}(::Type{C}) = base_colorant_type(color_type(C))
 
 base_color_type(c::Colorant) = base_color_type(typeof(c))
+base_color_type(x::Number)   = Gray
 
 @generated function base_colorant_type{C<:Colorant}(::Type{C})
     name = C.name.name
@@ -222,6 +223,7 @@ ccolor{T,Csrc<:AbstractRGB}(::Type{AbstractRGB{T}}, ::Type{Csrc}) = base_coloran
 
 # Concrete types
 ccolor{Cdest<:Colorant,Csrc<:Colorant}(::Type{Cdest}, ::Type{Csrc}) = base_colorant_type(Cdest){pick_eltype(color_type(Cdest), eltype(Cdest), eltype(Csrc))}
+ccolor{Cdest<:AbstractGray,T<:Union{Bool,Fractional}}(::Type{Cdest}, ::Type{T}) = base_colorant_type(Cdest){pick_eltype(color_type(Cdest), eltype(Cdest), T)}
 ccolor{Csrc<:Colorant}(::Type{RGB24},   ::Type{Csrc}) = RGB24
 ccolor{Csrc<:Colorant}(::Type{ARGB32},  ::Type{Csrc}) = ARGB32
 ccolor{Csrc<:Colorant}(::Type{Gray24},  ::Type{Csrc}) = Gray24

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -185,6 +185,8 @@ where `cnvt` is the function that performs explicit conversion.
 """
 ccolor{   Csrc<:Colorant}(::Type{Colorant   }, ::Type{Csrc}) = Csrc
 ccolor{T, Csrc<:Colorant}(::Type{Colorant{T}}, ::Type{Csrc}) = base_colorant_type(Csrc){T}
+ccolor{T, Csrc<:Color3  }(::Type{Colorant{T,3}}, ::Type{Csrc}) = Csrc
+ccolor{T, Csrc<:Transparent3}(::Type{Colorant{T,3}}, ::Type{Csrc}) = base_color_type(Csrc)
 ccolor{   Csrc<:Colorant}(::Type{Color   }, ::Type{Csrc}) = color_type(Csrc)
 ccolor{T, Csrc<:Colorant}(::Type{Color{T}}, ::Type{Csrc}) = base_color_type(Csrc){T}
 
@@ -221,18 +223,23 @@ ccolor{C<:Color,T,N,Csrc<:Colorant}(
 ccolor{  Csrc<:AbstractRGB}(::Type{AbstractRGB},    ::Type{Csrc}) = Csrc
 ccolor{T,Csrc<:AbstractRGB}(::Type{AbstractRGB{T}}, ::Type{Csrc}) = base_colorant_type(Csrc){T}
 
-# Concrete types
-ccolor{Cdest<:Colorant,Csrc<:Colorant}(::Type{Cdest}, ::Type{Csrc}) = base_colorant_type(Cdest){pick_eltype(color_type(Cdest), eltype(Cdest), eltype(Csrc))}
-ccolor{Cdest<:AbstractGray,T<:Union{Bool,Fractional}}(::Type{Cdest}, ::Type{T}) = base_colorant_type(Cdest){pick_eltype(color_type(Cdest), eltype(Cdest), T)}
+# Generic concrete types
+ccolor{Cdest<:Colorant,Csrc<:Colorant}(::Type{Cdest}, ::Type{Csrc}) = _ccolor(Cdest, Csrc, pick_eltype(Cdest, eltype(Cdest), eltype(Csrc)))
+ccolor{Cdest<:AbstractGray,T<:Union{Bool,Fractional}}(::Type{Cdest}, ::Type{T}) = _ccolor(Cdest, Gray{T}, pick_eltype(Cdest, eltype(Cdest), T))
+_ccolor{Cdest,Csrc,T<:Number}(::Type{Cdest}, ::Type{Csrc}, ::Type{T}) = base_colorant_type(Cdest){T}
+_ccolor{Cdest,Csrc}(          ::Type{Cdest}, ::Type{Csrc}, ::Any)     = Cdest
+
+# Specific concrete types
 ccolor{Csrc<:Colorant}(::Type{RGB24},   ::Type{Csrc}) = RGB24
 ccolor{Csrc<:Colorant}(::Type{ARGB32},  ::Type{Csrc}) = ARGB32
 ccolor{Csrc<:Colorant}(::Type{Gray24},  ::Type{Csrc}) = Gray24
 ccolor{Csrc<:Colorant}(::Type{AGray32}, ::Type{Csrc}) = AGray32
 
-pick_eltype{C,T1<:Number,T2            }(::Type{C}, ::Type{T1}, ::Type{T2}) = T1
+pick_eltype{C,T1<:Number,T2<:Number    }(::Type{C}, ::Type{T1}, ::Type{T2}) = T1
 pick_eltype{C,T1<:Number,T2<:FixedPoint}(::Type{C}, ::Type{T1}, ::Type{T2}) = T1
-pick_eltype{C,T2            }(::Type{C}, ::Any, ::Type{T2})     = T2
+pick_eltype{C,T2<:Number    }(::Type{C}, ::Any, ::Type{T2})     = T2
 pick_eltype{C,T2<:FixedPoint}(::Type{C}, ::Any, ::Type{T2})     = pick_eltype_compat(C, eltype_default(C), T2)
+pick_eltype{C               }(::Type{C}, ::Any, ::Any)          = eltype(C)
 # When T2 <: FixedPoint, choosed based on whether color type supports it
 pick_eltype_compat{T1            ,T2}(::Any, ::Type{T1}, ::Type{T2}) = T1
 pick_eltype_compat{T1<:FixedPoint,T2}(::Any, ::Type{T1}, ::Type{T2}) = T2

--- a/src/types.jl
+++ b/src/types.jl
@@ -291,7 +291,7 @@ ARGB32(r, g, b, alpha = 1) = ARGB32(U8(r), U8(g), U8(b), U8(alpha))
 """
 `Gray` is a grayscale object. You can extract its value with `gray(c)`.
 """
-immutable Gray{T<:Fractional} <: AbstractGray{T}
+immutable Gray{T<:Union{Fractional,Bool}} <: AbstractGray{T}
     val::T
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -52,6 +52,9 @@ using Base.Test
 @test @inferred(ccolor(Gray{U8}, Bool)) === Gray{U8}
 @test @inferred(ccolor(Gray,     Bool)) === Gray{Bool}
 
+@test @inferred(ccolor(RGB,  RGB))  === RGB
+@test @inferred(ccolor(Gray, Gray)) === Gray
+
 # Traits for instances (and their constructors)
 @test @inferred(eltype(RGB{U8}(1,0,0))) == U8
 @test @inferred(eltype(RGB(1.0,0,0))) == Float64
@@ -152,9 +155,9 @@ acargb = convert(ARGB, ac)
 
 @test convert(Colorant, acargb) === acargb
 @test convert(Colorant{U8},   acargb) === acargb
-@test_throws MethodError convert(Colorant{U8,3}, acargb)
-@test convert(TransparentColor,             acargb) == acargb
-@test convert(Color,                  acargb) == crgb
+@test convert(Colorant{U8,3}, acargb) === crgb
+@test convert(TransparentColor, acargb) == acargb
+@test convert(Color, acargb) == crgb
 
 @test red(c)   == red(ac)
 @test green(c) == green(ac)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -49,6 +49,9 @@ using Base.Test
 @test @inferred(ccolor(ARGB{U8},      HSV{Float32})) == ARGB{U8}
 @test @inferred(ccolor(ARGB,          HSV{Float32})) == ARGB{Float32}
 
+@test @inferred(ccolor(Gray{U8}, Bool)) === Gray{U8}
+@test @inferred(ccolor(Gray,     Bool)) === Gray{Bool}
+
 # Traits for instances (and their constructors)
 @test @inferred(eltype(RGB{U8}(1,0,0))) == U8
 @test @inferred(eltype(RGB(1.0,0,0))) == Float64
@@ -95,6 +98,13 @@ end
 c = Gray(0.8)
 @test gray(c) == 0.8
 @test gray(0.8) == 0.8
+c = convert(Gray, 0.8)
+@test c === Gray{Float64}(0.8)
+
+c = convert(Gray, true)
+@test c === Gray{Bool}(true)
+@test gray(c) === true
+@test gray(false) === false
 
 # Transparency
 for C in setdiff(ColorTypes.parametric3, [RGB1,RGB4])


### PR DESCRIPTION
`Bool` also makes sense as a `Gray`, so let's support that.

This also substantially generalizes `ccolor`, which is a core trait-method for generating a concrete type from underspecified types. Once tagged, this should fix the error described in https://github.com/JuliaIO/ImageMagick.jl/pull/34, CC @yuyichao.
