### PR TITLE
Speed up supertype operations using atsign-pure

### DIFF
--- a/src/ColorTypes.jl
+++ b/src/ColorTypes.jl
@@ -3,6 +3,13 @@ __precompile__()
 module ColorTypes
 
 using FixedPointNumbers
+if VERSION >= v"0.5.0-dev+755"
+    using Base.@pure
+else
+    macro pure(ex)
+        esc(ex)
+    end
+end
 
 typealias Fractional Union{AbstractFloat, FixedPoint}
 typealias U8 UFixed8

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -80,14 +80,14 @@ color{C,T}(c::TransparentColor{C,T,2}) = C(comp1(c))
 # recurse up the type hierarchy until you get to Colorant{T,N} for
 # specific T,N.
 to_top{T,N}(::Type{Colorant{T,N}}) = Colorant{T,N}
-to_top{C<:Colorant}(::Type{C}) = to_top(supertype(C))
+@pure to_top{C<:Colorant}(::Type{C}) = to_top(supertype(C))
 
 to_top(c::Colorant) = to_top(typeof(c))
 
 # eltype(RGB{Float32}) -> Float32
 eltype{T          }(::Type{Colorant{T}})   = T
 eltype{T,N        }(::Type{Colorant{T,N}}) = T
-eltype{C<:Colorant}(::Type{C}) = eltype(supertype(C))
+@pure eltype{C<:Colorant}(::Type{C}) = eltype(supertype(C))
 
 eltype(c::Colorant) = eltype(typeof(c))
 
@@ -95,7 +95,7 @@ eltype(c::Colorant) = eltype(typeof(c))
 # Note this is different from div(sizeof(c), sizeof(eltype(c))) (e.g., RGB1)
 length{T,N}(::Type{Colorant{T,N}}) = N
 length{N}(::Type{Colorant{TypeVar(:T),N}}) = N   # julia #12596
-length{C<:Colorant}(::Type{C}) = length(supertype(C))
+@pure length{C<:Colorant}(::Type{C}) = length(supertype(C))
 
 length(c::Colorant) = length(typeof(c))
 
@@ -113,8 +113,8 @@ For example,
     color_type(ARGB{U8})     == RGB{U8}
 """
 color_type{C<:Color}(::Type{C}) = C
-color_type{C<:AlphaColor}(::Type{C}) = color_type(supertype(C))
-color_type{C<:ColorAlpha}(::Type{C}) = color_type(supertype(C))
+@pure color_type{C<:AlphaColor}(::Type{C}) = color_type(supertype(C))
+@pure color_type{C<:ColorAlpha}(::Type{C}) = color_type(supertype(C))
 color_type{     }(::Type{TransparentColor})        = Color
 color_type{C    }(::Type{TransparentColor{C}})     = C
 color_type{C,T  }(::Type{TransparentColor{C,T}})   = C


### PR DESCRIPTION
This doesn't have any impact on 0.4, but it makes a few things a little faster with Julia 0.5.
