### PR TITLE
Add mapc for mapping functions elementwise over color channels

### DIFF
--- a/src/ColorTypes.jl
+++ b/src/ColorTypes.jl
@@ -46,6 +46,7 @@ export base_color_type, base_colorant_type, ccolor, color, color_type
 export alphacolor, coloralpha
 export alpha, red, green, blue, gray   # accessor functions that generalize to RGB24, etc.
 export comp1, comp2, comp3
+export mapc
 
 if VERSION < v"0.5.0-dev+1946"
     const supertype = super


### PR DESCRIPTION
This PR allows you to take the "elementwise max" over two RGBs:
```jl
mapc(max, rgb1, rgb2) -> rgbmax
```
