### PR TITLE
Throw informative errors for illegal construction

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ julia:
 notifications:
   email: false
 after_success:
-- julia -e 'cd(Pkg.dir("ColorTypes")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
+-  julia -e 'if VERSION >= v"0.6.0-dev.565" cd(Pkg.dir("ColorTypes")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder()); end'

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -1,3 +1,6 @@
+Base.promote_rule{T1<:AbstractGray,T2<:AbstractGray}(::Type{T1}, ::Type{T2}) = Gray{promote_type(eltype(T1), eltype(T2))}
+Base.promote_rule{T1<:AbstractRGB,T2<:AbstractRGB}(::Type{T1}, ::Type{T2}) = RGB{promote_type(eltype(T1), eltype(T2))}
+
 # no-op and element-type conversions, plus conversion to and from transparency
 # Colorimetry conversions are in Colors.jl
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -334,6 +334,11 @@ end
 @test AGray32(0x0duf8, 0x80uf8).color    == 0x800d0d0d
 @test convert(Gray{UFixed16}, Gray24(0x0duf8)) == Gray{UFixed16}(0.05098)
 
+@test promote(Gray{U8}(0.2), Gray24(0.3)) === (Gray{U8}(0.2), Gray{U8}(0.3))
+@test promote(Gray(0.2f0), Gray24(0.3)) === (Gray{Float32}(0.2), Gray{Float32}(U8(0.3)))
+@test promote(RGB{U8}(0.2,0.3,0.4), RGB24(0.3,0.8,0.1)) === (RGB{U8}(0.2,0.3,0.4), RGB{U8}(0.3,0.8,0.1))
+@test promote(RGB{Float32}(0.2,0.3,0.4), RGB24(0.3,0.8,0.1)) === (RGB{Float32}(0.2,0.3,0.4), RGB{Float32}(U8(0.3),U8(0.8),U8(0.1)))
+
 iob = IOBuffer()
 cf = RGB{Float32}(0.32218,0.14983,0.87819)
 c  = convert(RGB{U8}, cf)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,6 +11,10 @@ else
     end
 end
 
+if VERSION >= v"0.5.0"
+    @test isempty(detect_ambiguities(ColorTypes, Base, Core))
+end
+
 @test ColorTypes.to_top(AGray32(.8)) == ColorTypes.Colorant{FixedPointNumbers.UFixed{UInt8,8},2}
 @test @inferred(eltype(Color{U8})) == U8
 @test @inferred(eltype(RGB{Float32})) == Float32


### PR DESCRIPTION
I'm making a big push to make Images more newbie-friendly, and color handling is an important part of that. While at least some of us really like the fact that all (gray and RGB) color components lie in the range of 0 to 1, it's a perennial source of confusion for newbies. In https://github.com/JuliaMath/FixedPointNumbers.jl/pull/53 I added informative errors for conversion to fixed point, but I think it can be even nicer if we throw customized error messages here.

For example, the `InexactError` in https://github.com/JuliaGraphics/Colors.jl/issues/252 is now replaced with this:
```jl
julia> RGBA(56, 34, 23)
ERROR: ArgumentError: (56,34,23,1) are integers in the range 0-255, but integer inputs are encoded with the UFixed8
  type, an 8-bit type representing 256 discrete values between 0 and 1.
  Consider dividing your input values by 255, for example: RGBA{UFixed8}(56/255,34/255,23/255,1/255)
  See the READMEs for FixedPointNumbers and ColorTypes for more information.
 in throw_colorerror(::Type{FixedPointNumbers.UFixed{UInt8,8}}, ::Tuple{Int64,Int64,Int64,Int64}) at /home/tim/.julia/v0.5/ColorTypes/src/types.jl:615
 in throw_colorerror(::Type{FixedPointNumbers.UFixed{UInt8,8}}, ::Int64, ::Int64, ::Int64, ::Int64) at /home/tim/.julia/v0.5/ColorTypes/src/types.jl:585
 in checkval at /home/tim/.julia/v0.5/ColorTypes/src/types.jl:575 [inlined]
 in ColorTypes.RGBA{FixedPointNumbers.UFixed{UInt8,8}}(::Int64, ::Int64, ::Int64, ::Int64) at /home/tim/.julia/v0.5/ColorTypes/src/types.jl:453
 in ColorTypes.RGBA{T<:Union{AbstractFloat,FixedPointNumbers.FixedPoint}}(::Int64, ::Int64, ::Int64) at /home/tim/.julia/v0.5/ColorTypes/src/types.jl:478
```
which I think is rather friendlier.
