### PR TITLE
Add RGB24[::UInt32...] deprecations

### DIFF
--- a/src/ColorTypes.jl
+++ b/src/ColorTypes.jl
@@ -19,7 +19,7 @@ typealias U16 UFixed16
 
 "`U16` is an abbreviation for the UFixed16 type from FixedPointNumbers" U16
 
-import Base: ==, hash, convert, eltype, length, show, showcompact, one, zero, reinterpret, rand
+import Base: ==, hash, convert, eltype, length, show, showcompact, one, zero, reinterpret, rand, getindex
 
 ## Types
 export Fractional, U8, U16

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -41,10 +41,15 @@ _convert{A<:TransparentGray,C1<:AbstractGray,C2<:AbstractGray}(::Type{A}, ::Type
 _convert{A<:TransparentGray,C1<:AbstractGray,C2<:AbstractGray}(::Type{A}, ::Type{C1}, ::Type{C2}, c, alpha) = A(gray(c), alpha)
 
 
-@deprecate convert(::Type{UInt32}, c::RGB24) reinterpret(UInt32, c)
-@deprecate convert(::Type{UInt32}, c::ARGB32) reinterpret(UInt32, c)
-@deprecate convert(::Type{UInt32}, g::Gray24) reinterpret(UInt32, g)
-@deprecate convert(::Type{UInt32}, g::AGray32) reinterpret(UInt32, g)
+for T in (RGB24, ARGB32, Gray24, AGray32)
+    @eval begin
+        @deprecate convert(::Type{UInt32}, c::$T) reinterpret(UInt32, c)
+        @deprecate getindex(::Type{$T}, x::UInt32) $T[reinterpret($T, x)]
+        @deprecate getindex(::Type{$T}, x::UInt32, y::UInt32) $T[reinterpret($T, x), reinterpret($T, y)]
+        @deprecate getindex(::Type{$T}, x::UInt32, y::UInt32, z::UInt32) $T[reinterpret($T, x), reinterpret($T, y), reinterpret($T, z)]
+        @deprecate getindex(::Type{$T}, vals::UInt32...) $T[map(x->reinterpret($T, x), vals)...]
+    end
+end
 
 convert(::Type{RGB24},   x::Real) = RGB24(x, x, x)
 convert(::Type{ARGB32},  x::Real) = ARGB32(x, x, x, 1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -488,4 +488,10 @@ mktemp() do tmpfile, io
     @test sum(x->contains(x, "WARNING"), readlines(tmpfile)) == 12
 end
 
+# # deprecated
+# @test RGB24[0x00000000] == [RGB24(0)]
+# @test RGB24[0x00000000,0x00808080] == [RGB24(0), RGB24(0.5)]
+# @test RGB24[0x00000000,0x00808080,0x00ffffff] == [RGB24(0), RGB24(0.5), RGB24(1)]
+# @test RGB24[0x00000000,0x00808080,0x00ffffff,0x000000ff] == [RGB24(0), RGB24(0.5), RGB24(1), RGB24(0,0,1)]
+
 nothing


### PR DESCRIPTION
These were missed in the previous deprecations