### PR TITLE
Make `Gray.(a)` return a container with concrete type (if appropriate)

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -123,6 +123,9 @@ for val in (1.2, 1.2f0, UFixed12(1.2), Gray{UFixed12}(1.2), 2)
 end
 @test eltype(Gray()) == U8
 @test Gray(Gray()) == Gray()  # no StackOverflowError
+@test eltype(broadcast(Gray, rand(5))) == Gray{Float64}
+@test eltype(broadcast(Gray, rand(Float32,5))) == Gray{Float32}
+
 for C in ColorTypes.parametric3
     @test eltype(C{Float32}) == Float32
     et = (C <: AbstractRGB) ? U8 : Float32
@@ -419,6 +422,8 @@ for T in (Gray{U8}, AGray{Float32}, GrayA{Float64},
     @test isa(a, Array{T,2})
     @test size(a) == (3,5)
 end
+a = [BGR(1,0,0)]
+@test eltype(broadcast(RGB, a)) == RGB{U8}
 
 # colorfields
 @test ColorTypes.colorfields(AGray32(.2)) == (:color,:alpha)


### PR DESCRIPTION
This is (sort of) the other half of #59. On master we had this:
```jl
julia> b = Gray.(rand(3))
3-element Array{ColorTypes.Gray,1}:
 Gray{Float64}(0.914404)
 Gray{Float64}(0.682291)
 Gray{Float64}(0.530828)

julia> eltype(b)
ColorTypes.Gray{T<:Union{AbstractFloat,Bool,FixedPointNumbers.FixedPoint}}
```
i.e., an abstract eltype, even though the input has concrete eltype (`Float64`). This PR makes the return eltype `Gray{Float64}`.

In #59 I pointed out that `Gray[0.1]` constructs an array of abstract eltype, and proposed that we should fix it. I now think that's probably wrong. The reasons are:
- it's easy to get a concrete eltype, just say `Gray{Float64}[0.1]` (or whatever eltype you want, it will be converted)
- if we change it, then it will be awkward to create an array of abstract eltype (which can be useful in some situations): `b = Array{Gray}(1); b[1] = Gray(0.1)`
- in constructing an array this way, it's easy to control because you're supplying the values directly---this is a low-level construction syntax, not something that's used in generic programming deep in a nested function that has to handle arbitrary input types.

In contrast, `Gray.(a)` is useful in generic programming, and the alternative `Gray{eltype(a)}.(a)` isn't actually always what you want. (What if `a` is a `Vector{Int}`? You can't build the type `Gray{Int}`.) So it seems good to fix this one.

I only worry that this will set up an expectation that a concrete eltype will be provided everywhere, because it is (now) for `convert`, `map` (through generic techniques), and `broadcast`.
