### PR TITLE
Allow real(::Gray) as a synonym for gray(::Gray)

### DIFF
--- a/src/traits.jl
+++ b/src/traits.jl
@@ -35,6 +35,8 @@ gray(c::Gray24)  = UFixed8(c.color & 0x000000ff, 0)
 gray(c::AGray32) = UFixed8(c.color & 0x000000ff, 0)
 gray(x::Number)  = x
 
+Base.real(g::Gray) = gray(g)
+
 # Extract the first, second, and third arguments as you'd
 # pass them to the constructor
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -218,7 +218,7 @@ if VERSION >= v"0.5.0"
 end
 
 c = Gray(0.8)
-@test gray(c) == 0.8
+@test gray(c) == real(c) == 0.8
 @test gray(0.8) == 0.8
 c = convert(Gray, 0.8)
 @test c === Gray{Float64}(0.8)


### PR DESCRIPTION
In the context of `red(c)`, `green(c)`, and `blue(c)` for extracting the color channels of an RGB color `c`, the definition `gray(g)` to extract the value of a Gray color `g` makes sense. However, in isolation it is sometimes a bit weird: for example, if you want to get the `Float64` value that corresponds to grayscale for an RGB color,

```jl
julia> c = RGB(0.1, 0.2, 0.3)
RGB{Float64}(0.1,0.2,0.3)

julia> Gray(c)
Gray{Float64}(0.18150000199675562)

julia> gray(Gray(c))
0.18150000199675562
```

that `gray` seems somehow less natural than

```jl
julia> real(Gray(c))
0.18150000199675562
```

This PR allows either.