### PR TITLE
Move one/zero from ColorVectorSpace

### DIFF
--- a/src/traits.jl
+++ b/src/traits.jl
@@ -319,5 +319,7 @@ function ==(x::TransparentColor, y::TransparentColor)
 end
 
 
-zero{T}(::Type{Gray{T}}) = Gray{T}(zero(T))
-one{T}(::Type{Gray{T}}) = Gray{T}(one(T))
+zero{T<:Union{Fractional,Bool}}(::Type{Gray{T}}) = Gray{T}(zero(T))
+one{T<:Union{Fractional,Bool}}(::Type{Gray{T}}) = Gray{T}(one(T))
+zero{C<:Gray}(::Type{C}) = C(0)
+one{C<:Gray}(::Type{C}) = C(1)


### PR DESCRIPTION
Not sure how useful `one(Gray)` or `one(Gray{T} where T <: Fractional)` actually is but at least this solves the ambiguity error in ColorVectorSpace test.