### PR TITLE
Several performance enhancements

### DIFF
--- a/src/operations.jl
+++ b/src/operations.jl
@@ -96,10 +96,10 @@ color(s), returning an output color in the same colorspace.
     julia> mapc(+, RGB(0.1,0.8,0.3), RGB(0.5,0.5,0.5))
     RGB{Float64}(0.6,1.3,0.8)
 """
-mapc{C<:AbstractGray}(f, c::C) = base_color_type(C)(f(gray(c)))
-mapc{C<:TransparentGray}(f, c::C) = base_colorant_type(C)(f(gray(c)), f(alpha(c)))
-mapc{C<:Color3}(f, c::C) = base_color_type(C)(f(comp1(c)), f(comp2(c)), f(comp3(c)))
-mapc{C<:Transparent3}(f, c::C) = base_colorant_type(C)(f(comp1(c)), f(comp2(c)), f(comp3(c)), f(alpha(c)))
+@inline mapc{C<:AbstractGray}(f, c::C) = base_color_type(C)(f(gray(c)))
+@inline mapc{C<:TransparentGray}(f, c::C) = base_colorant_type(C)(f(gray(c)), f(alpha(c)))
+@inline mapc{C<:Color3}(f, c::C) = base_color_type(C)(f(comp1(c)), f(comp2(c)), f(comp3(c)))
+@inline mapc{C<:Transparent3}(f, c::C) = base_colorant_type(C)(f(comp1(c)), f(comp2(c)), f(comp3(c)), f(alpha(c)))
 
 mapc(f, x, y) = _mapc(_same_colorspace(x,y), f, x, y)
 _mapc{C<:AbstractGray}(::Type{C}, f, x, y) = C(f(gray(x), gray(y)))

--- a/src/types.jl
+++ b/src/types.jl
@@ -606,6 +606,12 @@ end
 @inline function checkval{T<:Normed}(::Type{T}, a, b, c, d)
     isok(T, a) & isok(T, b) & isok(T, c) & isok(T, d) || throw_colorerror(T, a, b, c, d)
 end
+
+checkval{T<:Normed}(::Type{T}, a::T) = nothing
+checkval{T<:Normed}(::Type{T}, a::T, b::T) = nothing
+checkval{T<:Normed}(::Type{T}, a::T, b::T, c::T) = nothing
+checkval{T<:Normed}(::Type{T}, a::T, b::T, c::T, d::T) = nothing
+
 checkval{T}(::Type{T}, a) = nothing
 checkval{T}(::Type{T}, a, b) = nothing
 checkval{T}(::Type{T}, a, b, c) = nothing


### PR DESCRIPTION
When visualizing big images I noticed several performance bottlenecks. This fixes some particularly important ones; in combination with changes in other packages (which I think are less important), in certain circumstances it's more than a 10-fold speedup. EDIT: the large magnitude depended on an inference failure triggered by https://github.com/JuliaMath/FixedPointNumbers.jl/pull/80 (which is presumably a bug in julia). It's still a speedup, though.
