### PR TITLE
Define mapc, reducec, and mapreducec for Numbers

### DIFF
--- a/src/operations.jl
+++ b/src/operations.jl
@@ -101,6 +101,8 @@ color(s), returning an output color in the same colorspace.
 @inline mapc{C<:Color3}(f, c::C) = base_color_type(C)(f(comp1(c)), f(comp2(c)), f(comp3(c)))
 @inline mapc{C<:Transparent3}(f, c::C) = base_colorant_type(C)(f(comp1(c)), f(comp2(c)), f(comp3(c)), f(alpha(c)))
 
+@inline mapc(f, x::Number) = f(x)
+
 mapc(f, x, y) = _mapc(_same_colorspace(x,y), f, x, y)
 _mapc{C<:AbstractGray}(::Type{C}, f, x, y) = C(f(gray(x), gray(y)))
 _mapc{C<:TransparentGray}(::Type{C}, f, x, y) = C(f(gray(x), gray(y)), f(alpha(x), alpha(y)))
@@ -128,10 +130,12 @@ whereas for RGB
 
 If `c` has an alpha channel, it is always the last one to be folded into the reduction.
 """
-@inline reducec{C<:AbstractGray}(op, v0, c::C) = op(v0, comp1(c))
-@inline reducec{C<:TransparentGray}(op, v0, c::C) = op(alpha(c), op(v0, comp1(c)))
-@inline reducec{C<:Color3}(op, v0, c::C) = op(comp3(c), op(comp2(c), op(v0, comp1(c))))
-@inline reducec{C<:Transparent3}(op, v0, c::C) = op(alpha(c), op(comp3(c), op(comp2(c), op(v0, comp1(c)))))
+@inline reducec(op, v0, c::AbstractGray) = op(v0, comp1(c))
+@inline reducec(op, v0, c::TransparentGray) = op(alpha(c), op(v0, comp1(c)))
+@inline reducec(op, v0, c::Color3) = op(comp3(c), op(comp2(c), op(v0, comp1(c))))
+@inline reducec(op, v0, c::Transparent3) = op(alpha(c), op(comp3(c), op(comp2(c), op(v0, comp1(c)))))
+
+@inline reducec(op, v0, x::Number) = op(v0, x)
 
 """
     mapreducec(f, op, v0, c)
@@ -148,7 +152,11 @@ whereas for RGB
 
 If `c` has an alpha channel, it is always the last one to be folded into the reduction.
 """
-@inline mapreducec{C<:AbstractGray}(f, op, v0, c::C) = op(v0, f(comp1(c)))
-@inline mapreducec{C<:TransparentGray}(f, op, v0, c::C) = op(f(alpha(c)), op(v0, f(comp1(c))))
-@inline mapreducec{C<:Color3}(f, op, v0, c::C) = op(f(comp3(c)), op(f(comp2(c)), op(v0, f(comp1(c)))))
-@inline mapreducec{C<:Transparent3}(f, op, v0, c::C) = op(f(alpha(c)), op(f(comp3(c)), op(f(comp2(c)), op(v0, f(comp1(c))))))
+@inline mapreducec(f, op, v0, c::AbstractGray) = op(v0, f(comp1(c)))
+@inline mapreducec(f, op, v0, c::TransparentGray) = op(f(alpha(c)), op(v0, f(comp1(c))))
+@inline mapreducec(f, op, v0, c::Color3) =
+    op(f(comp3(c)), op(f(comp2(c)), op(v0, f(comp1(c)))))
+@inline mapreducec(f, op, v0, c::Transparent3) =
+    op(f(alpha(c)), op(f(comp3(c)), op(f(comp2(c)), op(v0, f(comp1(c))))))
+
+@inline mapreducec(f, op, v0, x::Number) = op(v0, f(x))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -496,7 +496,7 @@ a = [BGR(1,0,0)]
 @test @inferred5(mapc(+, RGBA{N0f8}(0.2,0.8,0.7,0.3), RGBA{Float32}(0.5,0.2,0.99,0.5))) == RGBA(0.5f0+N0f8(0.2),0.2f0+N0f8(0.8),0.99f0+N0f8(0.7),0.5f0+N0f8(0.3))
 @test @inferred5(mapc(+, HSVA(0.1,0.8,0.3,0.5), HSVA(0.5,0.5,0.5,0.3))) == HSVA(0.1+0.5,0.8+0.5,0.3+0.5,0.5+0.3)
 @test_throws ArgumentError mapc(min, RGB{N0f8}(0.2,0.8,0.7), BGR{N0f8}(0.5,0.2,0.99))
-
+@test @inferred(mapc(abs, -2)) == 2
 
 @test @inferred(reducec(+, 0.0, Gray(0.3))) === 0.3
 @test @inferred(reducec(+, 1.0, Gray(0.3))) === 1.3
@@ -508,6 +508,12 @@ a = [BGR(1,0,0)]
 @test !(@inferred(reducec(&, false, Gray(true))))
 @test !(@inferred(reducec(&, true, Gray(false))))
 
+@test @inferred(reducec(+, 0.0, 0.3)) === 0.3
+@test @inferred(reducec(+, 0, 0.3)) === 0.3
+@test @inferred(reducec(&, true, true))
+@test !(@inferred(reducec(&, false, true)))
+@test !(@inferred(reducec(&, true, false)))
+
 @test @inferred(mapreducec(x->x^2, +, 0.0, Gray(0.3))) === 0.3^2
 @test @inferred(mapreducec(x->x^2, +, 1.0, Gray(0.3))) === 1 + 0.3^2
 @test @inferred(mapreducec(x->x^2, +, 0, Gray(0.3))) === 0.3^2
@@ -518,6 +524,14 @@ a = [BGR(1,0,0)]
 @test !(@inferred(mapreducec(x->!x, &, false, Gray(true))))
 @test @inferred(mapreducec(x->!x, &, true, Gray(false)))
 @test !@inferred(mapreducec(x->!x, &, false, Gray(false)))
+
+@test @inferred(mapreducec(x->x^2, +, 0.0, 0.3)) === 0.3^2
+@test @inferred(mapreducec(x->x^2, +, 1.0, 0.3)) === 1 + 0.3^2
+@test @inferred(mapreducec(x->x^2, +, 0, 0.3)) === 0.3^2
+@test !(@inferred(mapreducec(x->!x, &, true, true)))
+@test !(@inferred(mapreducec(x->!x, &, false, true)))
+@test @inferred(mapreducec(x->!x, &, true, false))
+@test !@inferred(mapreducec(x->!x, &, false, false))
 
 # issue #52
 @test AGray{BigFloat}(0.5,0.25) == AGray{BigFloat}(0.5,0.25)


### PR DESCRIPTION
Since we treat Numbers as a form of grayscale elsewhere, this seems to make sense. But I'd be interested in finding out whether others agree.