### PR TITLE
Use controlled promotion of field inputs in constructors

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -443,7 +443,7 @@ macro make_constructors(C, fields, elty)
     esc(quote
         # More constructors for the non-alpha version
         $C{T<:Integer}($(Tfields...)) = $C{$elty}($(fields...))
-        $C($(realfields...)) = $C(promote($(fields...))...)
+        $C($(realfields...)) = $C{promote_eltype($C, $(fields...))}($(fields...))
         $C() = $C{$elty}($(zfields...))
     end)
 end
@@ -533,6 +533,12 @@ eltype_default{P<:Colorant        }(::Type{P}) = eltype_default(color_type(P))
 eltype_ub{P<:Colorant        }(::Type{P}) = eltype_ub(eltype_default(P))
 eltype_ub{T<:FixedPoint   }(::Type{T}) = Fractional
 eltype_ub{T<:AbstractFloat}(::Type{T}) = AbstractFloat
+
+@inline promote_eltype{C<:Colorant}(::Type{C}, vals...) = _promote_eltype(eltype_ub(C), eltype_default(C), promote_type(map(typeof, vals)...))
+_promote_eltype{Tdef,T<:AbstractFloat}(::Type{AbstractFloat}, ::Type{Tdef}, ::Type{T}) = T
+_promote_eltype{Tdef,T<:Real}(::Type{AbstractFloat}, ::Type{Tdef}, ::Type{T}) = Tdef
+_promote_eltype{Tdef,T<:Fractional}(::Type{Fractional}, ::Type{Tdef}, ::Type{T}) = T
+_promote_eltype{Tdef,T<:Real}(::Type{Fractional}, ::Type{Tdef}, ::Type{T}) = Tdef
 
 ctypes = union(setdiff(parametric3, [RGB1,RGB4]), [Gray])
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -158,6 +158,11 @@ for C in filter(T -> T <: AbstractRGB, ColorTypes.color3types)
     @test green(c) == c.g == 0.5
     @test blue(c)  == c.b == 0
 end
+
+# #80
+z = N0f8(0)
+@test HSV(z, z, z) === HSV{Float32}(0, 0, 0)
+
 # Check various input types and values
 for C in filter(T -> T <: AbstractRGB, ColorTypes.color3types)
     for val1 in (0.2, 0.2f0, N0f8(0.2), N4f12(0.2), N0f16(0.2))


### PR DESCRIPTION
Fixes #80 (CC @rdeits).

This also happens to fix a weird issue I've noticed for a long time: that the tests pass when you say `using ColorTypes` (which precompiles the module), but not if you say `include("../src/ColorTypes.jl"); include("runtests.jl")`. Satisfying to have that gone.