### PR TITLE
WIP: Use Real in place of AbstractFloat and Fractional

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -161,7 +161,7 @@ end
 RGB4{T<:Fractional}(r::T, g::T, b::T) = RGB4{T}(r, g, b)
 
 "`HSV` is the Hue-Saturation-Value colorspace."
-immutable HSV{T<:AbstractFloat} <: Color{T,3}
+immutable HSV{T<:Real} <: Color{T,3}
     h::T # Hue in [0,360)
     s::T # Saturation in [0,1]
     v::T # Value in [0,1]
@@ -171,14 +171,14 @@ end
 const HSB = HSV
 
 "`HSL` is the Hue-Saturation-Lightness colorspace."
-immutable HSL{T<:AbstractFloat} <: Color{T,3}
+immutable HSL{T<:Real} <: Color{T,3}
     h::T # Hue in [0,360)
     s::T # Saturation in [0,1]
     l::T # Lightness in [0,1]
 end
 
 "`HSI` is the Hue-Saturation-Intensity colorspace."
-immutable HSI{T<:AbstractFloat} <: Color{T,3}
+immutable HSI{T<:Real} <: Color{T,3}
     h::T
     s::T
     i::T
@@ -189,63 +189,63 @@ end
 meaning that mathematical operations such as addition, subtraction,
 and scaling make "colorimetric sense" in this colorspace.
 """
-immutable XYZ{T<:AbstractFloat} <: Color{T,3}
+immutable XYZ{T<:Real} <: Color{T,3}
     x::T
     y::T
     z::T
 end
 
 "`xyY` is the CIE 1931 xyY (chromaticity + luminance) space"
-immutable xyY{T<:AbstractFloat} <: Color{T,3}
+immutable xyY{T<:Real} <: Color{T,3}
     x::T
     y::T
     Y::T
 end
 
 "`Lab` is the CIELAB colorspace."
-immutable Lab{T<:AbstractFloat} <: Color{T,3}
+immutable Lab{T<:Real} <: Color{T,3}
     l::T # Luminance in approximately [0,100]
     a::T # Red/Green
     b::T # Blue/Yellow
 end
 
 "`LCHab` is the Luminance-Chroma-Hue, Polar-Lab colorspace"
-immutable LCHab{T<:AbstractFloat} <: Color{T,3}
+immutable LCHab{T<:Real} <: Color{T,3}
     l::T # Luminance in [0,100]
     c::T # Chroma
     h::T # Hue in [0,360)
 end
 
 "`Luv` is the CIELUV colorspace"
-immutable Luv{T<:AbstractFloat} <: Color{T,3}
+immutable Luv{T<:Real} <: Color{T,3}
     l::T # Luminance
     u::T # Red/Green
     v::T # Blue/Yellow
 end
 
 "`LCHuv` is the Luminance-Chroma-Hue, Polar-Luv colorspace"
-immutable LCHuv{T<:AbstractFloat} <: Color{T,3}
+immutable LCHuv{T<:Real} <: Color{T,3}
     l::T # Luminance
     c::T # Chroma
     h::T # Hue
 end
 
 "`DIN99` is the (L99, a99, b99) adaptation of CIELAB"
-immutable DIN99{T<:AbstractFloat} <: Color{T,3}
+immutable DIN99{T<:Real} <: Color{T,3}
     l::T # L99
     a::T # a99
     b::T # b99
 end
 
 "`DIN99d` is the (L99d, a99d, b99d) improvement on DIN99"
-immutable DIN99d{T<:AbstractFloat} <: Color{T,3}
+immutable DIN99d{T<:Real} <: Color{T,3}
     l::T # L99d
     a::T # a99d
     b::T # b99d
 end
 
 "`DIN99o` is the (L99o, a99o, b99o) adaptation of CIELAB"
-immutable DIN99o{T<:AbstractFloat} <: Color{T,3}
+immutable DIN99o{T<:Real} <: Color{T,3}
     l::T # L99o
     a::T # a99o
     b::T # b99o
@@ -255,21 +255,21 @@ end
 `LMS` is the Long-Medium-Short colorspace based on activation of the
 three cone photoreceptors.  Like `XYZ`, this is a linear color space.
 """
-immutable LMS{T<:AbstractFloat} <: Color{T,3}
+immutable LMS{T<:Real} <: Color{T,3}
     l::T # Long
     m::T # Medium
     s::T # Short
 end
 
 "`YIQ` is a color encoding, for example used in NTSC transmission."
-immutable YIQ{T<:AbstractFloat} <: Color{T,3}
+immutable YIQ{T<:Real} <: Color{T,3}
     y::T
     i::T
     q::T
 end
 
 "`YCbCr` is the Y'CbCr color encoding often used in digital photography or video"
-immutable YCbCr{T<:AbstractFloat} <: Color{T,3}
+immutable YCbCr{T<:Real} <: Color{T,3}
     y::T
     cb::T
     cr::T


### PR DESCRIPTION
My goal is to do forward-mode automatic differentiation  through the colorimetry functions (see https://github.com/JuliaGraphics/ColorTypes.jl/issues/87).

Right now, I believe the element types for the colortypes are too restrictive. There's a good reason (https://github.com/JuliaGraphics/ColorTypes.jl/issues/87#issuecomment-313784538), but I'm hoping there's another way to accomplish that, and add it once we have generic type parameters.

With the current change (only changing the type definitions which use `<:AbstractFloat`), there's already trouble:

```julia
julia> convert(LMS, RGB(1,1,1))
ERROR: ArgumentError: FixedPointNumbers.Normed{UInt8,8} is an 8-bit type representing 256 values from 0.0 to 1.0; cannot represent 1.08883
Stacktrace:
 [1] throw_converterror(::Type{FixedPointNumbers.Normed{UInt8,8}}, ::Float64) at /Users/goretkin/.julia/v0.6/FixedPointNumbers/src/FixedPointNumbers.jl:170
 [2] _convert(::Type{FixedPointNumbers.Normed{UInt8,8}}, ::Type{UInt8}, ::Float64) at /Users/goretkin/.julia/v0.6/FixedPointNumbers/src/normed.jl:48
 [3] convert(::Type{ColorTypes.LMS}, ::ColorTypes.RGB{FixedPointNumbers.Normed{UInt8,8}}) at /Users/goretkin/.julia/v0.6/ColorTypes/src/conversions.jl:7
```

and the problem boils down to this commit causing:

```julia
julia> ColorTypes.issupported(LMS, eltype(RGB(1,1,1)))
true
```

whereas before it was `false`.

eltype(RGB(1,1,1)) is a subtype of `Real`, but it's not a subtype of `AbstractFloat`. If I follow the logic correctly, in the released version of `ColorTypes`, because `LMS` doesn't "support" the fixed-point type of `RGB(1,1,1)`, the values are promoted to `Float32` during conversion.

I'm looking for any suggestions for different logic to trigger this promotion. Probably any colorspace conversion from fixed point eltype (except perhaps to `Gray`, which is is a `<:Fractional` for whatever reason), should trigger a promotion to `Float32`.

