### PR TITLE
Switch to oneunit where appropriate

### DIFF
--- a/src/ColorTypes.jl
+++ b/src/ColorTypes.jl
@@ -12,7 +12,7 @@ const Fractional = Union{AbstractFloat, FixedPoint}
 Base.@deprecate_binding U8  N0f8
 Base.@deprecate_binding U16 N0f16
 
-import Base: ==, hash, convert, eltype, length, show, showcompact, one, zero, reinterpret, rand, getindex
+import Base: ==, hash, convert, eltype, length, show, showcompact, oneunit, zero, reinterpret, rand, getindex
 
 ## Types
 export Fractional

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -92,10 +92,14 @@ color(s), returning an output color in the same colorspace.
 @inline mapc(f, x::Number) = f(x)
 
 mapc(f, x, y) = _mapc(_same_colorspace(x,y), f, x, y)
-_mapc(::Type{C}, f, x, y) where {C<:AbstractGray} = C(f(gray(x), gray(y)))
-_mapc(::Type{C}, f, x, y) where {C<:TransparentGray} = C(f(gray(x), gray(y)), f(alpha(x), alpha(y)))
-_mapc(::Type{C}, f, x, y) where {C<:Color3} = C(f(comp1(x), comp1(y)), f(comp2(x), comp2(y)), f(comp3(x), comp3(y)))
-_mapc(::Type{C}, f, x, y) where {C<:Transparent3} = C(f(comp1(x), comp1(y)), f(comp2(x), comp2(y)), f(comp3(x), comp3(y)), f(alpha(x), alpha(y)))
+_mapc(::Type{C}, f, x::AbstractGray, y::AbstractGray) where C =
+    C(f(gray(x), gray(y)))
+_mapc(::Type{C}, f, x::TransparentGray, y::TransparentGray) where C =
+    C(f(gray(x), gray(y)), f(alpha(x), alpha(y)))
+_mapc(::Type{C}, f, x::Color3, y::Color3) where C =
+    C(f(comp1(x), comp1(y)), f(comp2(x), comp2(y)), f(comp3(x), comp3(y)))
+_mapc(::Type{C}, f, x::Transparent3, y::Transparent3) where C =
+    C(f(comp1(x), comp1(y)), f(comp2(x), comp2(y)), f(comp3(x), comp3(y)), f(alpha(x), alpha(y)))
 
 _same_colorspace(x::Colorant, y::Colorant) = _same_colorspace(base_colorant_type(x),
                                                               base_colorant_type(y))

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -5,7 +5,7 @@
 without an alpha channel, it will always return 1.
 """
 alpha(c::TransparentColor) = c.alpha
-alpha(c::Color)   = one(eltype(c))
+alpha(c::Color)   = oneunit(eltype(c))
 alpha(c::RGB24)   = N0f8(1)
 alpha(c::ARGB32)  = N0f8((c.color & 0xff000000)>>24, 0)
 alpha(c::AGray32) = N0f8((c.color & 0xff000000)>>24, 0)
@@ -317,7 +317,10 @@ function ==(x::TransparentColor, y::TransparentColor)
 end
 
 
-zero(::Type{Gray{T}}) where {T<:Union{Fractional,Bool}} = Gray{T}(zero(T))
-one(::Type{Gray{T}}) where {T<:Union{Fractional,Bool}} = Gray{T}(one(T))
 zero(::Type{C}) where {C<:Gray} = C(0)
-one(::Type{C}) where {C<:Gray} = C(1)
+oneunit(::Type{C}) where {C<:Gray} = C(1)
+
+function Base.one(::Type{C}) where {C<:Gray}
+    Base.depwarn("one($C) will soon switch to returning 1; you might need to switch to `oneunit`", :one)
+    C(1)
+end

--- a/src/types.jl
+++ b/src/types.jl
@@ -130,10 +130,10 @@ struct RGB1{T<:Fractional} <: AbstractRGB{T}
     g::T
     b::T
 
-    RGB1{T}(r::T, g::T, b::T) where {T} = new{T}(one(T), r, g, b)
+    RGB1{T}(r::T, g::T, b::T) where {T} = new{T}(oneunit(T), r, g, b)
     function RGB1{T}(r::Real, g::Real, b::Real) where T
         checkval(T, r, g, b)
-        new{T}(one(T), _rem(r,T), _rem(g,T), _rem(b,T))
+        new{T}(oneunit(T), _rem(r,T), _rem(g,T), _rem(b,T))
     end
 end
 RGB1(r::T, g::T, b::T) where {T<:Fractional} = RGB1{T}(r, g, b)
@@ -152,10 +152,10 @@ struct RGB4{T<:Fractional} <: AbstractRGB{T}
     b::T
     alphadummy::T
 
-    RGB4{T}(r::T, g::T, b::T) where {T} = new{T}(r, g, b, one(T))
+    RGB4{T}(r::T, g::T, b::T) where {T} = new{T}(r, g, b, oneunit(T))
     function RGB4{T}(r::Real, g::Real, b::Real) where T
         checkval(T, r, g, b)
-        new{T}(_rem(r,T), _rem(g,T), _rem(b,T), one(T))
+        new{T}(_rem(r,T), _rem(g,T), _rem(b,T), oneunit(T))
     end
 end
 RGB4(r::T, g::T, b::T) where {T<:Fractional} = RGB4{T}(r, g, b)
@@ -465,23 +465,23 @@ macro make_alpha(C, acol, cola, fields, constrfields, ub, elty)
             alpha::T
             $(Tfields...)
 
-            (::Type{$acol{T}})($(Tconstrfields...), alpha::T=one(T)) where {T} = new{T}(alpha, $(fields...))
-            function (::Type{$acol{T}})($(realfields...), alpha::Real=one(T)) where T
+            (::Type{$acol{T}})($(Tconstrfields...), alpha::T=oneunit(T)) where {T} = new{T}(alpha, $(fields...))
+            function (::Type{$acol{T}})($(realfields...), alpha::Real=oneunit(T)) where T
                 checkval(T, $(fields...), alpha)
                 new{T}(_rem(alpha,T), $(remfields...))
             end
-            $acol{T}(c::$C, alpha::Real=one(T)) where {T} = $acol{T}($(cfields...), alpha)
+            $acol{T}(c::$C, alpha::Real=oneunit(T)) where {T} = $acol{T}($(cfields...), alpha)
         end
         struct $cola{$Tconstr} <: ColorAlpha{$C{T}, T, $N}
             $(Tfields...)
             alpha::T
 
-            (::Type{$cola{T}})($(Tconstrfields...), alpha::T=one(T)) where {T} = new{T}($(fields...), alpha)
-            function (::Type{$cola{T}})($(realfields...), alpha::Real=one(T)) where T
+            (::Type{$cola{T}})($(Tconstrfields...), alpha::T=oneunit(T)) where {T} = new{T}($(fields...), alpha)
+            function (::Type{$cola{T}})($(realfields...), alpha::Real=oneunit(T)) where T
                 checkval(T, $(fields...), alpha)
                 new{T}($(remfields...), _rem(alpha,T))
             end
-            $cola{T}(c::$C, alpha::Real=one(T)) where {T} = $cola{T}($(cfields...), alpha)
+            $cola{T}(c::$C, alpha::Real=oneunit(T)) where {T} = $cola{T}($(cfields...), alpha)
         end
         $exportexpr
         alphacolor(::Type{C}) where {C<:$C} = $acol
@@ -489,7 +489,7 @@ macro make_alpha(C, acol, cola, fields, constrfields, ub, elty)
 
         # More constructors for the alpha versions
         $acol($(Tconstrfields...), alpha::T=1) where {T<:Integer} = $acol{$elty}($(fields...), alpha)
-        $acol(c::$C, alpha::Real=one(eltype(c))) = $acol{eltype(c)}(c, alpha)
+        $acol(c::$C, alpha::Real=oneunit(eltype(c))) = $acol{eltype(c)}(c, alpha)
         function $acol($(constrfields...))
             p = promote($(constrfields...))
             T = typeof(p[1])
@@ -504,7 +504,7 @@ macro make_alpha(C, acol, cola, fields, constrfields, ub, elty)
         $acol() = $acol{$elty}($(zfields...))
 
         $cola($(Tconstrfields...), alpha::T=1) where {T<:Integer} = $cola{$elty}($(fields...), alpha)
-        $cola(c::$C, alpha::Real=one(eltype(c))) = $cola{eltype(c)}(c, alpha)
+        $cola(c::$C, alpha::Real=oneunit(eltype(c))) = $cola{eltype(c)}(c, alpha)
         function $cola($(constrfields...))
             p = promote($(constrfields...))
             T = typeof(p[1])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -387,7 +387,7 @@ show(iob, cf)
 showcompact(iob, cf)
 @test String(take!(iob)) == "RGB{Float32}(0.32218,0.14983,0.87819)"
 
-@test one(Gray{N0f8}) == Gray{N0f8}(1)
+@test oneunit(Gray{N0f8}) == Gray{N0f8}(1)
 @test zero(Gray{N0f8}) == Gray{N0f8}(0)
 
 c = Gray(0.8)


### PR DESCRIPTION
This also modifies the implementation of a non-exported function for use in Colors
