### PR TITLE
Define isapprox and remove cruft

### DIFF
--- a/src/ColorTypes.jl
+++ b/src/ColorTypes.jl
@@ -12,7 +12,7 @@ const Fractional = Union{AbstractFloat, FixedPoint}
 Base.@deprecate_binding U8  N0f8
 Base.@deprecate_binding U16 N0f16
 
-import Base: ==, hash, convert, eltype, length, show, showcompact, oneunit, zero, reinterpret, rand, getindex
+import Base: ==, isapprox, hash, convert, eltype, length, show, showcompact, oneunit, zero, reinterpret, rand, getindex
 
 ## Types
 export Fractional

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -122,27 +122,14 @@ color_type(c::Colorant) = color_type(typeof(c))
 # Note this is different from div(sizeof(c), sizeof(eltype(c))) (e.g., RGB1)
 length(c::Colorant) = length(typeof(c))
 
-if isdefined(Core, :UnionAll)
-include_string(@__MODULE__, """
-    length(::Type{C}) where C<:(Colorant{T,N} where T) where N = N
-    # This definition should be unnecessary, but julia currently incorrectly
-    # dispatches to the first definition below, even when the second is
-    # applicable.
-    _color_type(::Type{TC}) where TC<:(TransparentColor{C, T, N} where T where N) where C = C
-    color_type(::Type{TC}) where TC<:TransparentColor =
-      isa(TC, UnionAll) ? parameter_upper_bound(TC, 1) : _color_type(TC)
-    color_type(::Type{TC}) where TC<:(TransparentColor{C, T, N} where T where N) where C = C
-""")
-else
-    length(::Type{Colorant{T,N}}) where {T,N} = N
-    length(::Type{Colorant{TypeVar(:T),N}}) where {N} = N   # julia #12596
-    @pure length(::Type{C}) where {C<:Colorant} = length(supertype(C))
-
-    color_type(::Type{TransparentColor{C}}) where {C    }     = C
-    color_type(::Type{TransparentColor{C,T}}) where {C,T  }   = C
-    color_type(::Type{TransparentColor{C,T,N}}) where {C,T,N} = C
-    color_type(::Type{TransparentColor{C,TypeVar(:T),N}}) where {C,N  } = C
-end
+length(::Type{C}) where C<:(Colorant{T,N} where T) where N = N
+# This definition should be unnecessary, but julia currently incorrectly
+# dispatches to the first definition below, even when the second is
+# applicable.
+_color_type(::Type{TC}) where TC<:(TransparentColor{C, T, N} where T where N) where C = C
+color_type(::Type{TC}) where TC<:TransparentColor =
+    isa(TC, UnionAll) ? parameter_upper_bound(TC, 1) : _color_type(TC)
+color_type(::Type{TC}) where TC<:(TransparentColor{C, T, N} where T where N) where C = C
 
 @pure color_type(::Type{C}) where {C<:AlphaColor} = color_type(supertype(C))
 @pure color_type(::Type{C}) where {C<:ColorAlpha} = color_type(supertype(C))
@@ -166,14 +153,7 @@ base_color_type(::Type{C}) where {C<:Colorant} = base_colorant_type(color_type(C
 base_color_type(c::Colorant) = base_color_type(typeof(c))
 base_color_type(x::Number)   = Gray
 
-if isdefined(Core, :UnionAll)
-    @pure basetype(T) = typename(T).wrapper
-else
-    @generated function basetype(::Type{C}) where C<:Colorant
-        name = C.name.name
-        :($name)
-    end
-end
+@pure basetype(T) = typename(T).wrapper
 base_colorant_type(::Type{C}) where {C<:Colorant} = basetype(C)
 
 """
@@ -192,7 +172,7 @@ and the easiest to use:
 """
 base_colorant_type(c::Colorant) = base_colorant_type(typeof(c))
 
-colorant_string(::Type{C}) where {C<:Colorant} = isdefined(Core, :UnionAll) ? string(Base.datatype_name(C)) : string(C.name.name)
+colorant_string(::Type{C}) where {C<:Colorant} = string(Base.datatype_name(C))
 
 """
  `ccolor` ("concrete color") helps write flexible methods. The idea is
@@ -257,15 +237,10 @@ ccolor(::Type{AbstractRGB{T}}, ::Type{Csrc}) where {T,Csrc<:AbstractRGB} = base_
 ccolor(::Type{Cdest}, ::Type{Csrc}) where {Cdest<:Colorant,Csrc<:Colorant} = _ccolor(Cdest, Csrc, pick_eltype(Cdest, eltype(Cdest), eltype(Csrc)))
 ccolor(::Type{Cdest}, ::Type{T}) where {Cdest<:AbstractGray,T<:Number} = _ccolor(Cdest, Gray, pick_eltype(Cdest, eltype(Cdest), T))
 
-if isdefined(Core, :UnionAll)
-include_string(@__MODULE__, """
-    _ccolor{Cdest,Csrc,T<:Number}(::Type{Cdest}, ::Type{Csrc}, ::Type{T}) = isconcrete(T) ?
-       base_colorant_type(Cdest){T} :
-       base_colorant_type(Cdest){S} where S<:T
-""")
-else
-    _ccolor(::Type{Cdest}, ::Type{Csrc}, ::Type{T}) where {Cdest,Csrc,T<:Number} = base_colorant_type(Cdest){T}
-end
+_ccolor(::Type{Cdest}, ::Type{Csrc}, ::Type{T}) where {Cdest,Csrc,T<:Number} =
+    isconcrete(T) ? base_colorant_type(Cdest){T} :
+                    base_colorant_type(Cdest){S} where S<:T
+
 _ccolor(          ::Type{Cdest}, ::Type{Csrc}, ::Any) where {Cdest,Csrc}     = Cdest
 
 # Specific concrete types
@@ -275,11 +250,7 @@ ccolor(::Type{Gray24},  ::Type{Csrc}) where {Csrc<:Colorant} = Gray24
 ccolor(::Type{AGray32}, ::Type{Csrc}) where {Csrc<:Colorant} = AGray32
 
 pick_eltype(::Type{C}, ::Type{T1}, ::Type{T2}) where {C,T1<:Number,T2<:Number} = T1
-if isdefined(Core, :UnionAll)
-    pick_eltype(::Type{C}, ::Any, ::Any) where {C} = eltypes_supported(C)
-else
-    @pure pick_eltype(::Type{C}, ::Any, ::Any) where {C} = TypeVar(:T, eltypes_supported(C))
-end
+pick_eltype(::Type{C}, ::Any, ::Any) where {C} = eltypes_supported(C)
 pick_eltype(::Type{C}, ::Any, ::Type{T2}) where {C,T2<:Number} = issupported(C, T2) ? T2 : eltype_default(C)
 
 ### Equality

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -317,6 +317,19 @@ function ==(x::TransparentColor, y::TransparentColor)
 end
 
 
+struct BoolTuple end
+@inline BoolTuple(args::Bool...) = (args...)
+
+function isapprox(a::C, b::C; kwargs...) where {C<:Colorant}
+    componentapprox(x, y) = isapprox(x, y; kwargs...)
+    all(ColorTypes._mapc(BoolTuple, componentapprox, a, b))
+end
+isapprox(x::Number, y::AbstractGray; kwargs...) =
+    isapprox(x, gray(y); kwargs...)
+isapprox(x::AbstractGray, y::Number; kwargs...) =
+    isapprox(y, x; kwargs...)
+
+
 zero(::Type{C}) where {C<:Gray} = C(0)
 oneunit(::Type{C}) where {C<:Gray} = C(1)
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -6,14 +6,14 @@ channel) information.  `T` is the element type (extractable with
 with `length`), i.e., the number of arguments you would supply to the
 constructor.
 """
-Compat.@compat abstract type Colorant{T,N} end
+abstract type Colorant{T,N} end
 
 # Colors (without transparency)
 """
 `Color{T,N}` is the abstract supertype for a color (or
 grayscale) with no transparency.
 """
-Compat.@compat abstract type Color{T, N} <: Colorant{T,N} end
+abstract type Color{T, N} <: Colorant{T,N} end
 
 """
 `AbstractRGB{T}` is an abstract supertype for red/green/blue color types that
@@ -23,7 +23,7 @@ assumptions about internal storage order, the number of fields, or the
 representation. One `AbstractRGB` color-type, `RGB24`, is not
 parametric and does not have fields named `r`, `g`, `b`.
 """
-Compat.@compat abstract type AbstractRGB{T}      <: Color{T,3} end
+abstract type AbstractRGB{T}      <: Color{T,3} end
 
 
 # Types with transparency
@@ -49,28 +49,28 @@ transparent analogs.  These two indicate different internal storage
 order (see `AlphaColor` and `ColorAlpha`, and the `alphacolor` and
 `coloralpha` functions).
 """
-Compat.@compat abstract type TransparentColor{C<:Color,T,N} <: Colorant{T,N} end
+abstract type TransparentColor{C<:Color,T,N} <: Colorant{T,N} end
 
 """
 `AlphaColor` is an abstract supertype for types like `ARGB`, where the
 alpha channel comes first in the internal storage order. **Note** that
 the constructor order is still `(color, alpha)`.
 """
-Compat.@compat abstract type AlphaColor{C,T,N} <: TransparentColor{C,T,N} end
+abstract type AlphaColor{C,T,N} <: TransparentColor{C,T,N} end
 
 """
 `ColorAlpha` is an abstract supertype for types like `RGBA`, where the
 alpha channel comes last in the internal storage order.
 """
-Compat.@compat abstract type ColorAlpha{C,T,N} <: TransparentColor{C,T,N} end
+abstract type ColorAlpha{C,T,N} <: TransparentColor{C,T,N} end
 
 # These are types we'll dispatch on. Not exported.
-Compat.@compat AbstractGray{T}                    = Color{T,1}
-Compat.@compat Color3{T}                          = Color{T,3}
-Compat.@compat TransparentGray{C<:AbstractGray,T} = TransparentColor{C,T,2}
-Compat.@compat Transparent3{C<:Color3,T}          = TransparentColor{C,T,4}
-Compat.@compat TransparentRGB{C<:AbstractRGB,T}   = TransparentColor{C,T,4}
-Compat.@compat ColorantNormed{T<:Normed,N}        = Colorant{T,N}
+AbstractGray{T}                    = Color{T,1}
+Color3{T}                          = Color{T,3}
+TransparentGray{C<:AbstractGray,T} = TransparentColor{C,T,2}
+Transparent3{C<:Color3,T}          = TransparentColor{C,T,4}
+TransparentRGB{C<:AbstractRGB,T}   = TransparentColor{C,T,4}
+ColorantNormed{T<:Normed,N}        = Colorant{T,N}
 
 """
 `RGB` is the standard Red-Green-Blue (sRGB) colorspace.  Values of the
@@ -561,7 +561,7 @@ for (C, acol, cola) in [(DIN99d, :ADIN99d, :DIN99dA),
     cfn = Expr(:tuple, colorfields(C)...)
     elty = eltype_default(C)
     ub   = eltype_ub(C)
-    Csym = isdefined(Core, :UnionAll) ? Base.datatype_name(Base.unwrap_unionall(C)) : C.name.name
+    Csym = Base.datatype_name(Base.unwrap_unionall(C))
     @eval @make_constructors $Csym $fn $elty
     @eval @make_alpha $Csym $acol $cola $fn $cfn $ub $elty
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -515,6 +515,15 @@ a = [BGR(1,0,0)]
 @test @inferred(mapreducec(x->!x, &, true, false))
 @test !@inferred(mapreducec(x->!x, &, false, false))
 
+@test Gray(0.8) ≈ Gray(0.8 + eps())
+@test Gray(0.8) ≈ 0.8 + eps()
+@test 0.8 + eps() ≈ Gray(0.8)
+@test GrayA(0.8, 0.4) ≈ GrayA(0.8 + eps(), 0.4)
+@test RGB(0.2, 0.8, 0.4) ≈ RGB(0.2, 0.8 + eps(), 0.4)
+@test RGBA(0.2, 0.8, 0.4, 0.2) ≈ RGBA(0.2, 0.8 + eps(), 0.4, 0.2 - eps())
+@test !(Gray(0.8) ≈ Gray(0.6))
+@test !(RGB(0.2, 0.8, 0.4) ≈ RGB(0.2, 0.8 + eps(), 0.5))
+
 # issue #52
 @test AGray{BigFloat}(0.5,0.25) == AGray{BigFloat}(0.5,0.25)
 @test RGBA{BigFloat}(0.5, 0.25, 0.5, 0.5) == RGBA{BigFloat}(0.5, 0.25, 0.5, 0.5)


### PR DESCRIPTION
I was planning to add this to Colors, but it actually seems to make the most sense here.

Also removes some cruft due to `UnionAll` checks.