### PR TITLE
Don't require precise type-equality for isapprox

### DIFF
--- a/src/traits.jl
+++ b/src/traits.jl
@@ -313,10 +313,21 @@ end
 struct BoolTuple end
 @inline BoolTuple(args::Bool...) = (args...)
 
-function isapprox(a::C, b::C; kwargs...) where {C<:Colorant}
+function _isapprox(a::Colorant, b::Colorant; kwargs...)
     componentapprox(x, y) = isapprox(x, y; kwargs...)
     all(ColorTypes._mapc(BoolTuple, componentapprox, a, b))
 end
+isapprox(a::C, b::C; kwargs...) where {C<:Colorant} =
+    _isapprox(a, b; kwargs...)
+isapprox(a::Colorant, b::Colorant; kwargs...) =
+    _isapprox(base_colorant_type(a), base_colorant_type(b), a, b; kwargs...)
+_isapprox(::Type{C}, ::Type{C}, a, b; kwargs...) where {C<:Colorant} =
+    _isapprox(a, b; kwargs...)
+_isapprox(::Type{<:AbstractRGB}, ::Type{<:AbstractRGB}, a, b; kwargs...) =
+    _isapprox(RGB(a), RGB(b); kwargs...)
+_isapprox(::Type{<:AbstractGray}, ::Type{<:AbstractGray}, a, b; kwargs...) =
+    isapprox(gray(a), gray(b); kwargs...)
+_isapprox(TA::Type, TB::Type, a, b; kwargs...) = false
 isapprox(x::Number, y::AbstractGray; kwargs...) =
     isapprox(x, gray(y); kwargs...)
 isapprox(x::AbstractGray, y::Number; kwargs...) =

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -548,6 +548,16 @@ a = [BGR(1,0,0)]
 @test RGBA(0.2, 0.8, 0.4, 0.2) ≈ RGBA(0.2, 0.8 + eps(), 0.4, 0.2 - eps())
 @test !(Gray(0.8) ≈ Gray(0.6))
 @test !(RGB(0.2, 0.8, 0.4) ≈ RGB(0.2, 0.8 + eps(), 0.5))
+@test Gray(0.8f0) ≈ Gray(Float64(0.8f0 + eps(0.8f0)))
+c = RGB{N0f8}(0.2, 0.8, 0.4)
+c1 = mapc(Float32, c)
+@test c == c1 && c ≈ c1
+c2 = RGB(red(c1), green(c1)-0.1, blue(c1))
+@test c ≈ c2 atol=0.11
+@test !isapprox(c, c2; atol=0.09)
+@test c ≈ convert(RGB4, c)
+@test !(c ≈ HSV{Float32}(140.0f0,0.75f0,0.8f0))  # the latter comes from convert when using Colors
+@test Gray(0.8N0f8) == Gray24(0.8) && Gray(0.8N0f8) ≈ Gray24(0.8)
 
 # issue #52
 @test AGray{BigFloat}(0.5,0.25) == AGray{BigFloat}(0.5,0.25)


### PR DESCRIPTION
This fixes a test failure in Images.
