### PR TITLE
fixes for Julia v0.7

### DIFF
--- a/src/ColorTypes.jl
+++ b/src/ColorTypes.jl
@@ -7,7 +7,7 @@ using Base: @pure
 
 import Compat
 using Compat.TypeUtils
-using Compat: @__MODULE__, isabstracttype, isconcretetype, uninitialized
+using Compat: @__MODULE__, isabstracttype, isconcretetype, undef
 
 const Fractional = Union{AbstractFloat, FixedPoint}
 Base.@deprecate_binding U8  N0f8

--- a/src/show.jl
+++ b/src/show.jl
@@ -10,7 +10,7 @@ show_normed(io::IO, c::ARGB32) = print(io, "ARGB32(", red(c), ',', green(c), ','
 
 for N = 1:4
     component = N >= 3 ? (:comp1, :comp2, :comp3, :alpha) : (:comp1, :alpha)
-    printargs = Array{Any}(uninitialized, 2, N)
+    printargs = Array{Any}(undef, 2, N)
     for i = 1:N
         printargs[1,i] = :(show(io, $(component[i])(c)))
         chr = i < N ? ',' : ')'

--- a/src/types.jl
+++ b/src/types.jl
@@ -411,7 +411,7 @@ AGray32(g::AbstractGray, alpha = 1) = AGray32(gray(g), alpha)
 # traits in the rest of this file are intended just for internal use
 
 const color3types = map(s->getfield(ColorTypes,s),
-  filter(names(ColorTypes, false)) do s
+  filter(names(ColorTypes, all=false)) do s
     isdefined(ColorTypes, s) || return false
     t = getfield(ColorTypes, s)
     isa(t, Type) && t <: Colorant && !isabstracttype(t) && length(fieldnames(t))>1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 using ColorTypes, FixedPointNumbers
 using Compat, Compat.Test
 
-@test isempty(detect_ambiguities(ColorTypes, Base, Core))
+# @test isempty(Test.detect_ambiguities(ColorTypes, Base, Core))
 
 # Support pre- and post- julia #20288
 tformat(x...) = join(string.(x), ", ")
@@ -61,7 +61,7 @@ tformat(x...) = join(string.(x), ", ")
 @test @inferred(ccolor(Gray,     Bool)) === Gray{Bool}
 @test @inferred(ccolor(Gray,     Int))  === Gray{N0f8}
 # This tests the same thing as the last, but in a user-observable way
-let a = Array{Gray}(uninitialized, 1)
+let a = Array{Gray}(undef, 1)
     a[1] = Gray(0)
     a[1] = 1
     @test a[1] === Gray(1)
@@ -207,11 +207,11 @@ for C in filter(T -> T <: AbstractRGB, ColorTypes.color3types)
 end
 
 ret = @test_throws ArgumentError RGB(255, 17, 48)
-@test contains(ret.value.msg, tformat(255,17,48))
-@test contains(ret.value.msg, "0-255")
+@test occursin(tformat(255,17,48), ret.value.msg)
+@test occursin("0-255", ret.value.msg)
 ret = @test_throws ArgumentError RGB(256, 17, 48)
-@test contains(ret.value.msg, tformat(256,17,48))
-@test !contains(ret.value.msg, "0-255")
+@test occursin(tformat(256,17,48), ret.value.msg)
+@test !occursin("0-255", ret.value.msg)
 
 @testset "Test some Gray stuff" begin
     c = Gray(0.8)
@@ -383,11 +383,11 @@ show(iob, c)
 c = RGBA{N0f8}(0.32218,0.14983,0.87819,0.99241)
 show(iob, c)
 @test String(take!(iob)) == "RGBA{N0f8}(0.322,0.149,0.878,0.992)"
-showcompact(iob, c)
+show(IOContext(iob, :compact => true), c)
 @test String(take!(iob)) == "RGBA{N0f8}(0.322,0.149,0.878,0.992)"
 show(iob, cf)
 @test String(take!(iob)) == "RGB{Float32}(0.32218f0,0.14983f0,0.87819f0)"
-showcompact(iob, cf)
+show(IOContext(iob, :compact => true), cf)
 @test String(take!(iob)) == "RGB{Float32}(0.32218,0.14983,0.87819)"
 show(iob, Gray24(0.4))
 @test String(take!(iob)) == "Gray24(0.4N0f8)"
@@ -555,7 +555,7 @@ end
 @test !(RGB(0.2, 0.8, 0.4) ≈ RGB(0.2, 0.8 + eps(), 0.5))
 @test Gray(0.8f0) ≈ Gray(Float64(0.8f0 + eps(0.8f0)))
 c = RGB{N0f8}(0.2, 0.8, 0.4)
-c1 = mapc(Float32, c)
+c1 = mapc(x->convert(Float32,x), c)
 @test c == c1 && c ≈ c1
 c2 = RGB(red(c1), green(c1)-0.1, blue(c1))
 @test c ≈ c2 atol=0.11

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 using ColorTypes, FixedPointNumbers
 using Compat, Compat.Test
 
-# @test isempty(Test.detect_ambiguities(ColorTypes, Base, Core))
+@test isempty(Test.detect_ambiguities(ColorTypes, Base, Core))
 
 # Support pre- and post- julia #20288
 tformat(x...) = join(string.(x), ", ")


### PR DESCRIPTION
Everything passes without warnings on 0.6 and 0.7, except this test, which I don't know how to fix:
```jl
@test isempty(Test.detect_ambiguities(ColorTypes, Base, Core))
```
The output of `detect_ambiguities` is empty on 0.6 and as follows on 0.7:
```jl
Test.detect_ambiguities(ColorTypes, Base, Core) = Tuple{Method,Method}[
(
  (::Type{Fixed{T,f}})(x) where {T, f} in FixedPointNumbers at /home/rene/.julia/v0.7/FixedPointNumbers/src/fixed.jl:8,
  (::Type{T})(x::AbstractChar) where T<:Union{AbstractChar, Number} in Base at char.jl:50
),
(
  (::Type{Normed{T,f}})(x) where {T, f} in FixedPointNumbers at /home/rene/.julia/v0.7/FixedPointNumbers/src/normed.jl:8,
  (::Type{T})(x::AbstractChar) where T<:Union{AbstractChar, Number} in Base at char.jl:50
)
]
```
