### PR TITLE
Fixes needed for ImageCore

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,13 +55,13 @@ end
 RGBs may be defined with two broad number types: `FloatingPoint` and
 `FixedPoint`.  `FixedPoint` come from the
 [`FixedPointNumbers`](https://github.com/JeffBezanson/FixedPointNumbers.jl)
-package, and represent fractional numbers (between 0 and 1, inclusive)
-internally using integers.  For example, `0xffuf8` creates a `Ufixed8`
-(`U8` for short) number with value equal to `1.0` but which internally
+package, and represent fractional numbers
+internally using integers.  For example, `N0f8(1)` creates a `Normed{UInt8,8}`
+(`N0f8` for short) number with value equal to `1.0` but which internally
 is represented as `0xff`.  This strategy ensures that `1` always means
 "saturated color", regardless of how that value is represented.
 Ordinary integers should not be used, although the convenience
-constructor `RGB(1,0,0)` will create a value `RGB{U8}(1.0, 0.0, 0.0)`.
+constructor `RGB(1,0,0)` will create a value `RGB{N0f8}(1.0, 0.0, 0.0)`.
 
 The analogous `BGR` type is defined as
 
@@ -80,14 +80,14 @@ are arranged internally in memory**.
 
 `RGB1` and `RGB4` seem exactly like `RGB`, but internally they insert
 one extra ("invisible") padding element; when the element type is
-`U8`, these have favorable memory alignment for interfacing with
+`N0f8`, these have favorable memory alignment for interfacing with
 libraries like OpenGL.
 
 Finally, one may represent an RGB color as 8-bit values packed into a
 32-bit integer:
 
 ```julia
-struct RGB24 <: AbstractRGB{U8}
+struct RGB24 <: AbstractRGB{N0f8}
     color::UInt32
 end
 ```
@@ -323,7 +323,7 @@ end
 
 `Gray` is a simple wrapper around a number:
 ```jl
-immutable Gray{T} <: Color{T,1}
+immutable Gray{T} <: AbstractGray{T}
     val::T
 end
 ```
@@ -338,7 +338,7 @@ types, `AGray` and `GrayA`.
 
 `Gray24` is a grayscale value encoded as a `UInt32`:
 ```jl
-immutable Gray24 <: Color{U8,1}
+immutable Gray24 <: AbstractGray{N0f8}
     color::UInt32
 end
 ```
@@ -360,15 +360,15 @@ set of trait-functions for working with color types:
   with transparency (either `ARGB` or `RGBA`, respectively).
 
 - `color_type(c)` extracts the opaque (color-only) type of the object (e.g.,
-  `RGB{U8}` from an object of type `ARGB{U8}`).
+  `RGB{N0f8}` from an object of type `ARGB{N0f8}`).
 
 - `base_color_type(c)` and `base_colorant_type(c)` extract type
   information and discard the element type (e.g.,
-  `base_colorant_type(ARGB{U8})` yields `ARGB`)
+  `base_colorant_type(ARGB{N0f8})` yields `ARGB`)
 
 - `ccolor(Cdest, Csrc)` helps pick a concrete element type for methods
   where the output may be left unstated, e.g., `convert(RGB, c)`
-  rather than `convert(RGB{U8}, c)`.
+  rather than `convert(RGB{N0f8}, c)`.
 
 All of these methods are individually documented (typically with
 greater detail); just type `?ccolor` at the REPL.

--- a/src/ColorTypes.jl
+++ b/src/ColorTypes.jl
@@ -7,7 +7,9 @@ using Base: @pure
 
 const Fractional = Union{AbstractFloat, FixedPoint}
 
-import Base: ==, isapprox, hash, convert, eltype, length, show, oneunit, zero, reinterpret, rand, getindex
+import Base: ==, isapprox, hash, convert, eltype, length, show, oneunit, zero, reinterpret, getindex
+using Random
+import Random: rand
 
 ## Types
 export Fractional

--- a/src/ColorTypes.jl
+++ b/src/ColorTypes.jl
@@ -6,8 +6,6 @@ using FixedPointNumbers
 using Base: @pure
 
 const Fractional = Union{AbstractFloat, FixedPoint}
-Base.@deprecate_binding U8  N0f8
-Base.@deprecate_binding U16 N0f16
 
 import Base: ==, isapprox, hash, convert, eltype, length, show, oneunit, zero, reinterpret, rand, getindex
 

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -56,13 +56,9 @@ convert(::Type{GrayA{T}}, x::Real) where {T}    = GrayA{T}(x)
 
 # Define some constructors that just call convert since the fallback constructor in Base
 # is removed in Julia 0.7
-for t in (:ARGB32, :Gray24, :RGB1, :RGB4, :RGB24)
+# The parametric types are handled in @make_constructors and @make_alpha
+for t in (:ARGB32, :Gray24, :RGB24)
     @eval $t(x) = convert($t, x)
-end
-for t in (:ARGB, :BGR, :DIN99, :DIN99d, :DIN99o, :Gray, :HSI, :HSL, :HSV, :LCHab, :LCHuv, :LMS, :Lab, :Luv, :RGB, :RGBA, :XYZ, :xyY, :YCbCr, :YIQ)
-    @eval $t(x) = convert($t, x)
-    ex = :($(t){T}(x) where {T} = convert($(t){T}, x))
-    @eval $ex
 end
 
 # Generate the transparent analog of a color

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -461,6 +461,9 @@ for T in (Gray{N0f8}, Gray{N2f6}, Gray{N0f16}, Gray{N2f14}, Gray{N0f32}, Gray{N2
                 zip(ColorTypes.colorfields(T),gamutmin(T),gamutmax(T)))
     @test isa(a, T)
     a = rand(T, (3, 5))
+    if isconcretetype(T)
+        @test isa(a, Array{T,2})
+    end
     for el in a
         @test all(x->x[2]<=getfield(el,x[1])<=x[3],
                     zip(ColorTypes.colorfields(T),gamutmin(T),gamutmax(T)))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -222,6 +222,12 @@ ret = @test_throws ArgumentError RGB(256, 17, 48)
 
     ac = convert(AGray, c)
     @test ac === AGray{Float64}(0.8, 1.0)
+    ac = AGray(c)
+    @test ac === AGray{Float64}(0.8, 1.0)
+    ac = AGray{Float64}(c)
+    @test ac === AGray{Float64}(0.8, 1.0)
+    ca = GrayA{Float64}(ac)
+    @test ca === GrayA{Float64}(0.8, 1.0)
 
     c = AGray(0.8)
     @test gray(c) == 0.8
@@ -259,12 +265,20 @@ for C in setdiff(ColorTypes.parametric3, [RGB1,RGB4])
         @test C(c         ) == C{Float64}(1,0.8,0.6)
         @test C{Float32}(c) == C{Float32}(1,0.8,0.6)
         @test convert(A, cc) == A{Float64}(1,0.8,0.6,1)
+        @test A(cc) === A{Float64}(1,0.8,0.6,1)
+        @test A{Float64}(cc) === A{Float64}(1,0.8,0.6,1)
         @test convert(A, cc, 0.4)  == c
         @test convert(A, cc, 0x01) == A{Float64}(1,0.8,0.6,1)
         @test convert(A{Float32}, cc, 0x01) == A{Float32}(1,0.8,0.6,1)
         @test convert(C,          c) == C{Float64}(1,0.8,0.6)
         @test convert(C{Float32}, c) == C{Float32}(1,0.8,0.6)
+        @test C{Float32}(c) === C{Float32}(1,0.8,0.6)
     end
+    AC, CA = alphacolor(C), coloralpha(C)
+    @test AC(CA{Float64}(1,0.8,0.6,0.4)) == AC{Float64}(1,0.8,0.6,0.4)
+    @test AC{Float64}(CA{Float64}(1,0.8,0.6,0.4)) == AC{Float64}(1,0.8,0.6,0.4)
+    @test CA(AC{Float64}(1,0.8,0.6,0.4)) == CA{Float64}(1,0.8,0.6,0.4)
+    @test CA{Float64}(AC{Float64}(1,0.8,0.6,0.4)) == CA{Float64}(1,0.8,0.6,0.4)
 end
 ac = reinterpret(ARGB32, rand(UInt32))
 @test convert(ARGB32, ac) == ac


### PR DESCRIPTION
As a PR this is a grab-bag, but each commit makes sense on its own.
- Formerly, `AGray{Float64}(GrayA(0.1, 0.2))` was throwing a depwarn about constructors no longer falling back to `convert`
- We were still using `U8` in the README! :confounded: 
- `rand` now returns an `Array` rather than a `ReinterpretedArray` (it does the reinterpreting internally)
