### PR TITLE
Export types used in other packages of the Images.jl project

### DIFF
--- a/src/ColorTypes.jl
+++ b/src/ColorTypes.jl
@@ -14,7 +14,7 @@ export Fractional
 
 export Colorant
 export Color, TransparentColor, AlphaColor, ColorAlpha, AbstractRGB
-export AbstractGray, TransparentGray, TransparentRGB
+export AbstractGray, Color3, TransparentGray, Transparent3, TransparentRGB, ColorantNormed
 
 export RGB, BGR, RGB1, RGB4
 export HSV, HSB, HSL, HSI

--- a/src/ColorTypes.jl
+++ b/src/ColorTypes.jl
@@ -14,6 +14,7 @@ export Fractional
 
 export Colorant
 export Color, TransparentColor, AlphaColor, ColorAlpha, AbstractRGB
+export AbstractGray, TransparentGray, TransparentRGB
 
 export RGB, BGR, RGB1, RGB4
 export HSV, HSB, HSL, HSI

--- a/src/types.jl
+++ b/src/types.jl
@@ -64,7 +64,7 @@ alpha channel comes last in the internal storage order.
 """
 abstract type ColorAlpha{C,T,N} <: TransparentColor{C,T,N} end
 
-# These are types we'll dispatch on. Not exported.
+# These are types we'll dispatch on.
 AbstractGray{T}                    = Color{T,1}
 Color3{T}                          = Color{T,3}
 TransparentGray{C<:AbstractGray,T} = TransparentColor{C,T,2}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -632,4 +632,20 @@ end
     @test_throws ArgumentError RGB24[0x00000000,0x00808080,0x00ffffff,0x000000ff]
 end
 
+
+### Prevent future commits from unexporting abstract types
+@testset "abstract type exports" begin
+    dispatcher(::AbstractGray) = 1
+    dispatcher(::Color3) = 2
+    dispatcher(::TransparentGray) = 3
+    dispatcher(Transparent3) = 4
+    dispatcher(::TransparentRGB) = 5
+    dispatcher(::ColorantNormed) = 6
+
+    @test dispatcher(Gray(0.2)) == 1
+    @test dispatcher(RGB(1.0,1.0,1.0)) == 2
+    @test dispatcher(AGray(0.2,0.5)) == 3
+    @test dispatcher(ARGB(0.5,1.0,1.0,1.0)) == 5
+end
+
 nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -640,13 +640,16 @@ end
     dispatcher(::TransparentGray) = 3
     dispatcher(Transparent3) = 4
     dispatcher(::TransparentRGB) = 5
-    dispatcher(::ColorantNormed) = 6
+    normeddispatcher(::ColorantNormed) = true
+    normeddispatcher(::Colorant) = false
 
     @test dispatcher(Gray(0.2)) == 1
     @test dispatcher(RGB(1.0,1.0,1.0)) == 2
     @test dispatcher(AGray(0.2,0.5)) == 3
     @test dispatcher(alphacolor(rand(HSV))) == 4
     @test dispatcher(ARGB(0.5,1.0,1.0,1.0)) == 5
+    @test normeddispatcher(RGB(1.0,1.0,1.0)) == false
+    @test normeddispatcher(RGB{N0f8}(1.0,1.0,1.0)) == true
 end
 
 nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -645,6 +645,7 @@ end
     @test dispatcher(Gray(0.2)) == 1
     @test dispatcher(RGB(1.0,1.0,1.0)) == 2
     @test dispatcher(AGray(0.2,0.5)) == 3
+    @test dispatcher(alphacolor(rand(HSV))) == 4
     @test dispatcher(ARGB(0.5,1.0,1.0,1.0)) == 5
 end
 


### PR DESCRIPTION
This PR exports missing types used in other packages of the Images.jl project. I appreciate if you can review and merge. I will submit another PR to Colors.jl and Images.jl meanwhile.