### PR TITLE
expand floattype from FixedPointNumbers

### DIFF
--- a/src/ColorTypes.jl
+++ b/src/ColorTypes.jl
@@ -1,6 +1,7 @@
 module ColorTypes
 
 using FixedPointNumbers
+import FixedPointNumbers: floattype
 using Base: @pure
 
 const Fractional = Union{AbstractFloat, FixedPoint}

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -172,6 +172,26 @@ and the easiest to use:
 """
 base_colorant_type(c::Colorant) = base_colorant_type(typeof(c))
 
+"""
+    floattype(::Type{T}) where T<:Colorant
+
+Promote storage data type of colorant `T` to `AbstractFloat` while keep the
+`base_colorant_type` the same.
+
+!!! info
+
+    Non-parametric colorants will be promote to corresponding parametric
+    colorants. For example, `floattype(RGB24) == RGB{Float32}`
+"""
+floattype(::Type{T}) where T <: Colorant =
+    base_colorant_type(T){floattype(eltype(T))} # 1 parameter
+# 0 parameter
+floattype(::Type{RGB24}) = RGB{Float32}
+floattype(::Type{Gray24}) = Gray{Float32}
+floattype(::Type{ARGB32}) = ARGB{Float32}
+floattype(::Type{AGray32}) = AGray{Float32}
+
+
 colorant_string(::Type{Union{}}) = "Union{}"
 colorant_string(::Type{C}) where {C<:Colorant} = string(nameof(C))
 function colorant_string_with_eltype(::Type{C}) where {C<:Colorant}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,8 @@
 using ColorTypes, FixedPointNumbers
 using Test
 
+@testset "ColorTypes" begin
+
 @test isempty(detect_ambiguities(ColorTypes, Base, Core))
 
 # Support pre- and post- julia #20288
@@ -47,6 +49,21 @@ tformat(x...) = join(string.(x), ", ")
 @test @inferred(base_colorant_type(BGR{N0f8})      ) == BGR
 @test @inferred(base_colorant_type(HSV) ) == HSV
 @test @inferred(base_colorant_type(HSVA)) == HSVA
+
+@testset "floattype" begin
+    @test @inferred(floattype(RGBA{Float32})) == RGBA{Float32}
+    @test @inferred(floattype(BGR{N0f8})    ) == BGR{Float32}
+    @test @inferred(floattype(Gray{N0f8})   ) == Gray{Float32}
+    @test @inferred(floattype(N0f8)         ) == Float32
+    @test @inferred(floattype(Bool)         ) == Float32
+    @test @inferred(floattype(Float32)      ) == Float32
+    @test @inferred(floattype(Float64)      ) == Float64
+
+    @test @inferred(floattype(ARGB32)) == ARGB{Float32}
+    @test @inferred(floattype(AGray32)) == AGray{Float32}
+    @test @inferred(floattype(RGB24)) == RGB{Float32}
+    @test @inferred(floattype(Gray24)) == Gray{Float32}
+end
 
 @test @inferred(ccolor(Colorant{N0f8,3}, BGR{N0f8})) == BGR{N0f8}
 
@@ -658,5 +675,7 @@ end
     @test RGB(0.2, 0.3, Gray(0.4)) == RGB(0.2, 0.3, 0.4)
     @test RGB(Gray(0.2), Gray(0.3), Gray(0.4)) == RGB(0.2, 0.3, 0.4)
 end
+
+end # ColorTypes
 
 nothing


### PR DESCRIPTION
This patch is a generalization of https://github.com/JuliaImages/Images.jl/issues/803#issuecomment-488139972

Expanding the existing `FixedPointNumbers.floattype` seems reasonable to me, but if there are concerns on type piracy, I'm also happy to use a new name.

Blocking PR:

- [x] https://github.com/JuliaMath/FixedPointNumbers.jl/pull/122