### PR TITLE
extend float for Colorant (closes #123)

### DIFF
--- a/src/ColorTypes.jl
+++ b/src/ColorTypes.jl
@@ -6,7 +6,7 @@ using Base: @pure
 
 const Fractional = Union{AbstractFloat, FixedPoint}
 
-import Base: ==, isapprox, hash, convert, eltype, length, show, oneunit, zero, reinterpret, getindex
+import Base: ==, isapprox, hash, convert, eltype, length, show, oneunit, zero, reinterpret, getindex, float
 using Random
 import Random: rand
 

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -191,6 +191,13 @@ floattype(::Type{Gray24}) = Gray{Float32}
 floattype(::Type{ARGB32}) = ARGB{Float32}
 floattype(::Type{AGray32}) = AGray{Float32}
 
+"""
+    float(x::Colorant)
+
+convert the storage type of pixel `x` to a floating point data type.
+"""
+float(x::Colorant) = floattype(typeof(x))(x)
+float(::Type{T}) where T <: Colorant = floattype(T)
 
 colorant_string(::Type{Union{}}) = "Union{}"
 colorant_string(::Type{C}) where {C<:Colorant} = string(nameof(C))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -65,6 +65,26 @@ tformat(x...) = join(string.(x), ", ")
     @test @inferred(floattype(Gray24)) == Gray{Float32}
 end
 
+@testset "float" begin
+    # float(::Type) is equivalent to floattype
+    @test @inferred(float(RGBA{Float32})) == RGBA{Float32}
+    @test @inferred(float(BGR{N0f8})    ) == BGR{Float32}
+    @test @inferred(float(Gray{N0f8})   ) == Gray{Float32}
+    @test @inferred(float(N0f8)         ) == Float32
+    @test @inferred(float(Bool)         ) == Float32
+    @test @inferred(float(Float32)      ) == Float32
+    @test @inferred(float(Float64)      ) == Float64
+
+    @test @inferred(float(ARGB32)) == ARGB{Float32}
+    @test @inferred(float(AGray32)) == AGray{Float32}
+    @test @inferred(float(RGB24)) == RGB{Float32}
+    @test @inferred(float(Gray24)) == Gray{Float32}
+
+    # float(x::Colorant)
+    @test float(ones(Gray{N0f8}, 4, 4)) == ones(Gray{Float32}, 4, 4)
+    @test float(RGB.(ones(Gray{N0f8}, 4, 4))) == RGB.(ones(Gray{Float32}, 4, 4))
+end
+
 @test @inferred(ccolor(Colorant{N0f8,3}, BGR{N0f8})) == BGR{N0f8}
 
 @test @inferred(ccolor(RGB{Float32}, HSV{Float32})) == RGB{Float32}


### PR DESCRIPTION
With `floattype` introduced in #121, one can promote the image from `Gray{N0f8}` to `Gray{Float32}` easily with the following code:

```julia
floattype(eltype(img)).(img)
```

While a perhaps more natural and easier way of doing this is to extend `float` for `Colorant` and use

```julia
float.(img) # promote Gray{N0f8} to Gray{Float32}
```