### PR TITLE
Add support for "Type" input of `TransparentColor` to `alphacolor`/`coloralpha` (#126)

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -587,6 +587,11 @@ for C in (RGB, BGR, RGB1, RGB4)
     @eval (::Type{$C{T}})(r::GrayLike, g::GrayLike, b::GrayLike) where T = $C{T}(gray(r), gray(g), gray(b))
 end
 
+alphacolor(::Type{C}) where {C<:AlphaColor} = base_colorant_type(C)
+alphacolor(::Type{C}) where {C<:ColorAlpha} = alphacolor(base_color_type(C))
+coloralpha(::Type{C}) where {C<:ColorAlpha} = base_colorant_type(C)
+coloralpha(::Type{C}) where {C<:AlphaColor} = coloralpha(base_color_type(C))
+
 alphacolor(::Type{C}) where {C<:Gray24} = AGray32
 alphacolor(::Type{C}) where {C<:RGB24} = ARGB32
 alphacolor(::Type{C}) where {C<:RGB1} = ARGB

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,6 +23,26 @@ tformat(x...) = join(string.(x), ", ")
 @test length(ARGB32) == 4
 @test length(AGray{Float32}) == 2
 
+# coloralpha/alphacolor for `TransparentColor`s (issue #126)
+@test @inferred(coloralpha(RGBA)) == RGBA
+@test @inferred(coloralpha(ARGB)) == RGBA
+@test @inferred(coloralpha(RGBA{Float32})) == RGBA
+@test @inferred(coloralpha(ARGB{Float32})) == RGBA
+@test @inferred(coloralpha(AGray)) == GrayA
+@test @inferred(coloralpha(GrayA)) == GrayA
+@test @inferred(coloralpha(AGray{Float32})) == GrayA
+@test @inferred(coloralpha(GrayA{Float32})) == GrayA
+@test_throws MethodError coloralpha(ARGB32)
+@test @inferred(alphacolor(RGBA)) == ARGB
+@test @inferred(alphacolor(ARGB)) == ARGB
+@test @inferred(alphacolor(RGBA{Float32})) == ARGB
+@test @inferred(alphacolor(ARGB{Float32})) == ARGB
+@test @inferred(alphacolor(AGray)) == AGray
+@test @inferred(alphacolor(GrayA)) == AGray
+@test @inferred(alphacolor(AGray{Float32})) == AGray
+@test @inferred(alphacolor(GrayA{Float32})) == AGray
+@test @inferred(alphacolor(ARGB32)) == ARGB32
+
 @test @inferred(color_type(RGB{N0f8})) == RGB{N0f8}
 @test @inferred(color_type(RGB)) == RGB
 @test @inferred(color_type(RGBA{Float32})) == RGB{Float32}
@@ -328,6 +348,8 @@ acargb = convert(ARGB, ac)
 @test convert(Colorant{N0f8,3}, acargb) === crgb
 @test convert(TransparentColor, acargb) == acargb
 @test convert(Color, acargb) == crgb
+@test convert(AlphaColor, acargb) === acargb # issue #126
+@test convert(ColorAlpha, acargb) == coloralpha(acargb) # issue #126
 
 h = N0f8(0.5)
 @test Gray24(0.5) == Gray24(h)


### PR DESCRIPTION
e.g. alphacolor(RGBA) == ARGB, coloralpha(ARGB) == ARGB
This helps the conversion from `AlphaColor` to `ColorAlpha` or vice versa. (fixes #126)