### PR TITLE
Add `chroma()` and `hue()` (#134)

### DIFF
--- a/src/ColorTypes.jl
+++ b/src/ColorTypes.jl
@@ -35,6 +35,7 @@ export RGB24, ARGB32, Gray24, AGray32
 export base_color_type, base_colorant_type, ccolor, color, color_type
 export alphacolor, coloralpha
 export alpha, red, green, blue, gray   # accessor functions that generalize to RGB24, etc.
+export chroma, hue
 export comp1, comp2, comp3
 export mapc, reducec, mapreducec, gamutmax, gamutmin
 

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -37,6 +37,28 @@ gray(x::Number)  = x
 
 Base.real(g::Gray) = gray(g)
 
+"""
+`chroma(c)` returns the chroma of a `Lab`, `Luv` or their variants color.
+!!! note
+    The other color types (e.g. `RGB`, `HSV` or `YCbCr`) are not supported
+    because their definitions of *chroma* are not clear. Colorfulness, chroma
+    and saturation are defined as distinct aspects by the CIE.
+"""
+chroma(c::Union{C,AlphaColor{C},ColorAlpha{C}}) where {C<:Union{Lab,DIN99,DIN99o,DIN99d}} = sqrt(c.a^2 + c.b^2)
+chroma(c::Union{C,AlphaColor{C},ColorAlpha{C}}) where {C<:Luv} = sqrt(c.u^2 + c.v^2)
+chroma(c::Union{C,AlphaColor{C},ColorAlpha{C}}) where {C<:Union{LCHab,LCHuv}} = c.c
+
+"""
+`hue(c)` returns the hue in degrees. This function does not guarantee that the
+return value is in [0, 360].
+"""
+hue(c::Union{C,AlphaColor{C},ColorAlpha{C}}) where {C<:Union{HSV,HSL,HSI,LCHab,LCHuv}} = c.h
+hue(c::Union{C,AlphaColor{C},ColorAlpha{C}}) where {C<:Union{Lab,DIN99,DIN99o,DIN99d}} =
+    (h = atand(c.b, c.a); h < 0 ? h + 360 : h)
+hue(c::Union{C,AlphaColor{C},ColorAlpha{C}}) where {C<:Luv} =
+    (h = atand(c.v, c.u); h < 0 ? h + 360 : h)
+
+
 # Extract the first, second, and third arguments as you'd
 # pass them to the constructor
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -403,6 +403,37 @@ for C in filter(T -> T <: AbstractRGB, ColorTypes.color3types)
     @test rgba.b == blue(ac)
 end
 
+@testset "chroma" begin
+    for C in [Lab, DIN99, DIN99o, DIN99d, Luv]
+        @test chroma(C(60, -40, 30)) ≈ 50.0
+    end
+    @test chroma(LCHab(60, 40, 30)) ≈ 40.0
+    @test chroma(LCHuv(60, 40, 30)) ≈ 40.0
+    @test chroma(LabA(60, -40, 30, 0.5)) ≈ 50.0
+    @test chroma(ALab(60, -40, 30, 0.5)) ≈ 50.0
+    @inferred chroma(LCHab(60, 40, 30))
+    @inferred chroma(LCHuv(6f1, 4f1, 3f1))
+    @inferred chroma(LabA(60, -40, 30, 0.5))
+    @test_throws MethodError chroma(HSV(30, 0.4, 0.6))
+end
+
+@testset "hue" begin
+    @test hue(HSV(30, 0.4, 0.6)) ≈ 30.0
+    @test hue(HSL(30, 0.4, 0.6)) ≈ 30.0
+    @test hue(HSI(30, 0.4, 0.6)) ≈ 30.0
+    for C in [Lab, DIN99, DIN99o, DIN99d, Luv]
+        @test hue(C(60, -30, 30)) ≈ 135.0
+    end
+    @test hue(LCHab(60, 40, 30)) ≈ 30.0
+    @test hue(LCHuv(60, 40, 30)) ≈ 30.0
+    @test hue(LabA(60, -30, 30, 0.5)) ≈ 135.0
+    @test hue(ALab(60, -30, 30, 0.5)) ≈ 135.0
+    @inferred hue(LCHab(60, -30, 30))
+    @inferred hue(LCHuv(6f1, -3f1, 3f1))
+    @inferred hue(LabA(60, -30, 30, 0.5))
+    @test hue(HSV(999, 0.4, 0.6)) == 999 # without normalization
+end
+
 @test_throws ErrorException convert(HSV, RGB(1,0,1))
 @test_throws ErrorException convert(AHSV, RGB(1,0,1), 0.5)
 


### PR DESCRIPTION
This adds and exports two functions for (mainly) Lab-like colors (cf. #134).