### PR TITLE
[RFC/WIP] Add abstract types for gamut definitions (#139)

### DIFF
--- a/src/ColorTypes.jl
+++ b/src/ColorTypes.jl
@@ -27,6 +27,8 @@ export Gray
 
 export RGB24, ARGB32, Gray24, AGray32
 
+export AbstractGamut, AbstractRGBGamut, Gamut_sRGB
+
 # Note: the parametric TransparentColorColors are exported
 # algorithmically, see `@make_alpha` in types.jl.
 
@@ -40,6 +42,7 @@ export comp1, comp2, comp3
 export mapc, reducec, mapreducec, gamutmax, gamutmin
 
 include("types.jl")
+include("gamut.jl")
 include("traits.jl")
 include("conversions.jl")
 include("show.jl")

--- a/src/gamut.jl
+++ b/src/gamut.jl
@@ -35,7 +35,7 @@ function gamutmin(colorspace::Type{T},
     (gamutmin(color_type(T), Gamut_sRGB)..., 0)
 end
 
-function gamutin(::Type{T}, gamut::AbstractGamut) where {T<:Colorant}
+function gamutmin(::Type{T}, gamut::AbstractGamut) where {T<:Colorant}
     gamutmin(T, typeof(gamut)) # fallback
 end
 

--- a/src/gamut.jl
+++ b/src/gamut.jl
@@ -1,0 +1,88 @@
+
+abstract type AbstractGamut end
+
+abstract type AbstractRGBGamut <: AbstractGamut end
+
+abstract type Gamut_sRGB <: AbstractRGBGamut end
+
+"""
+    gamutmax(colorspace, gamut=Gamut_sRGB)
+
+Returns the upper bound of `gamut` in `colorspace`. If the `gamut` exceeds the
+upper bound of the `colorspace`, the latter is returned.
+"""
+gamutmax(::Type{T}) where {T<:Color} = gamutmax(T, Gamut_sRGB)
+
+function gamutmax(colorspace::Type{T},
+                  gamut::Type{<:AbstractGamut}=Gamut_sRGB) where {T<:TransparentColor}
+    (gamutmax(color_type(T), Gamut_sRGB)..., 1)
+end
+
+function gamutmax(::Type{T}, gamut::AbstractGamut) where {T<:Colorant}
+    gamutmax(T, typeof(gamut)) # fallback
+end
+
+"""
+    gamutmin(colorspace, gamut=Gamut_sRGB)
+
+Returns the lower bound of `gamut` in `colorspace`. If the `gamut` exceeds (is
+below) the lower bound of the `colorspace`, the latter is returned.
+"""
+gamutmin(::Type{T}) where {T<:Color} = gamutmin(T, Gamut_sRGB)
+
+function gamutmin(colorspace::Type{T},
+                  gamut::Type{<:AbstractGamut}=Gamut_sRGB) where {T<:TransparentColor}
+    (gamutmin(color_type(T), Gamut_sRGB)..., 0)
+end
+
+function gamutin(::Type{T}, gamut::AbstractGamut) where {T<:Colorant}
+    gamutmin(T, typeof(gamut)) # fallback
+end
+
+
+# the following values based on the D65 whitepoint
+gamutmin(::Type{<:Color3}, ::Type{Gamut_sRGB}) = (0,0,0)
+
+gamutmax(::Type{<:AbstractRGB}, ::Type{Gamut_sRGB}) = (1,1,1)
+
+gamutmax(::Type{<:HSV}, ::Type{Gamut_sRGB}) = (360,1,1)
+
+gamutmax(::Type{<:HSL}, ::Type{Gamut_sRGB}) = (360,1,1)
+
+gamutmax(::Type{<:HSI}, ::Type{Gamut_sRGB}) = (360,1,1)
+
+gamutmax(::Type{<:XYZ}, ::Type{Gamut_sRGB}) = (0.9505,1,1.089)
+
+gamutmax(::Type{<:xyY}, ::Type{Gamut_sRGB}) = (0.3127,0.3290,1)
+
+
+gamutmax(::Type{<:Lab}, ::Type{Gamut_sRGB}) = (100,98.2343,94.4779)
+gamutmin(::Type{<:Lab}, ::Type{Gamut_sRGB}) = (0,-86.1827,-107.8602)
+
+gamutmax(::Type{<:Luv}, ::Type{Gamut_sRGB}) = (100,175.0150,107.3985)
+gamutmin(::Type{<:Luv}, ::Type{Gamut_sRGB}) = (0,-83.077,-134.1030)
+
+gamutmax(::Type{<:LCHab}, ::Type{Gamut_sRGB}) = (100,133.8076,360)
+
+gamutmax(::Type{<:LCHuv}, ::Type{Gamut_sRGB}) = (100,179.0414,360)
+
+gamutmax(::Type{<:DIN99}, ::Type{Gamut_sRGB}) = (100.0013,36.1753,31.1551)
+gamutmin(::Type{<:DIN99}, ::Type{Gamut_sRGB}) = (0,-27.4504,-33.3955)
+
+gamutmax(::Type{<:DIN99d}, ::Type{Gamut_sRGB}) = (100.0002,43.6867,43.6318)
+gamutmin(::Type{<:DIN99d}, ::Type{Gamut_sRGB}) = (0,-38.1436,-45.8498)
+
+gamutmax(::Type{<:DIN99o}, ::Type{Gamut_sRGB}) = (99.9997,45.5242,44.3662)
+gamutmin(::Type{<:DIN99o}, ::Type{Gamut_sRGB}) = (0,-40.1101,-40.4900)
+
+# LMS colorspace depends on color appearance models.
+gamutmax(::Type{<:LMS}, ::Type{Gamut_sRGB}) = (0.9493,1.0354,1.0872)
+
+gamutmax(::Type{<:YIQ}, ::Type{Gamut_sRGB}) = (1,0.5957,0.5226)
+gamutmin(::Type{<:YIQ}, ::Type{Gamut_sRGB}) = (0,-0.5957,-0.5226)
+
+gamutmax(::Type{<:YCbCr}, ::Type{Gamut_sRGB}) = (235,240,240)
+gamutmin(::Type{<:YCbCr}, ::Type{Gamut_sRGB}) = (16,16,16)
+
+gamutmax(::Type{<:AbstractGray}, ::Type{Gamut_sRGB}) = (1,)
+gamutmin(::Type{<:AbstractGray}, ::Type{Gamut_sRGB}) = (0,)

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -6,27 +6,6 @@ hash(c::TransparentRGB, hx::UInt) = hash(alpha(c), hash(blue(c), hash(green(c), 
 
 Base.adjoint(c::Colorant) = c
 
-# gamut{min,max}
-gamutmax(::Type{T}) where {T<:HSV} = (360,1,1)
-gamutmin(::Type{T}) where {T<:HSV} = (0,0,0)
-gamutmax(::Type{T}) where {T<:HSL} = (360,1,1)
-gamutmin(::Type{T}) where {T<:HSL} = (0,0,0)
-gamutmax(::Type{T}) where {T<:Lab} = (100,128,128)
-gamutmin(::Type{T}) where {T<:Lab} = (0,-127,-127)
-gamutmax(::Type{T}) where {T<:LCHab} = (100,1,360)
-gamutmin(::Type{T}) where {T<:LCHab} = (0,0,0)
-gamutmax(::Type{T}) where {T<:YIQ} = (1,0.5226,0.5226)
-gamutmin(::Type{T}) where {T<:YIQ} = (0,-0.5957,-0.5957)
-
-gamutmax(::Type{T}) where {T<:AbstractGray} = (1,)
-gamutmax(::Type{T}) where {T<:TransparentGray} = (1,1)
-gamutmax(::Type{T}) where {T<:AbstractRGB} = (1,1,1)
-gamutmax(::Type{T}) where {T<:TransparentRGB} = (1,1,1,1)
-gamutmin(::Type{T}) where {T<:AbstractGray} = (0,)
-gamutmin(::Type{T}) where {T<:TransparentGray} = (0,0)
-gamutmin(::Type{T}) where {T<:AbstractRGB} = (0,0,0)
-gamutmin(::Type{T}) where {T<:TransparentRGB} = (0,0,0,0)
-
 # rand
 for t in [Float16,Float32,Float64,N0f8,N0f16,N0f32]
     @eval _rand(::Type{T}) where {T<:Union{AbstractRGB{$t},AbstractGray{$t}}} =


### PR DESCRIPTION
This adds abstract types for the gamut definitions (cf. #139, #125).

This also changes the `gamutmin`/`gamutmax` definitions. The new `gamutmin`/`gamutmax` mean the corners of the *minimum bounding box* of the (implicitly) specified gamut. Specifying the gamut (i.e. "sRGB") specifies the range *somewhat* formally.

**Edit:**
Of course, if we allow breaking changes, we also have the option of moving these to `Colors.jl`. I think `rand()` (with gamuts) is too complex for `ColorTypes.jl`, a *minimal* package.