### PR TITLE
[RFC] Move type aliases `AbstractAGray`/`AbstractGrayA` from Colors.jl

### DIFF
--- a/src/ColorTypes.jl
+++ b/src/ColorTypes.jl
@@ -16,6 +16,7 @@ export Fractional
 export Colorant
 export Color, TransparentColor, AlphaColor, ColorAlpha, AbstractRGB
 export AbstractGray, Color3, TransparentGray, Transparent3, TransparentRGB, ColorantNormed
+export AbstractAGray, AbstractGrayA, AbstractARGB, AbstractRGBA
 
 export RGB, BGR, XRGB, RGBX
 export HSV, HSB, HSL, HSI

--- a/src/types.jl
+++ b/src/types.jl
@@ -71,6 +71,10 @@ TransparentGray{C<:AbstractGray,T} = TransparentColor{C,T,2}
 Transparent3{C<:Color3,T}          = TransparentColor{C,T,4}
 TransparentRGB{C<:AbstractRGB,T}   = TransparentColor{C,T,4}
 ColorantNormed{T<:Normed,N}        = Colorant{T,N}
+AbstractAGray{C<:AbstractGray,T}   = AlphaColor{C,T,2}
+AbstractGrayA{C<:AbstractGray,T}   = ColorAlpha{C,T,2}
+AbstractARGB{C<:AbstractRGB,T}     = AlphaColor{C,T,4}
+AbstractRGBA{C<:AbstractRGB,T}     = ColorAlpha{C,T,4}
 
 """
 `RGB` is the standard Red-Green-Blue (sRGB) colorspace.  Values of the
@@ -325,7 +329,7 @@ you can still extract the individual components with `alpha(c)`,
 `red(c)`, `green(c)`, `blue(c)`.  You can construct them directly from
 a `UInt32`, or as `ARGB32(r, g, b, alpha)`.
 """
-struct ARGB32 <: AlphaColor{RGB24, N0f8, 4}
+struct ARGB32 <: AbstractARGB{RGB24, N0f8}
     color::UInt32
 
     ARGB32(col::UInt32, ::Type{Val{true}}) = new(col)
@@ -384,7 +388,7 @@ You can extract the single gray value with `gray(c)` and the alpha as
 `AGray32(i,alpha)`. Note that `i` and `alpha` are interpreted on a
 scale from 0 (black) to 1 (white).
 """
-struct AGray32 <: AlphaColor{Gray24, N0f8, 2}
+struct AGray32 <: AbstractAGray{Gray24, N0f8}
     color::UInt32
 
     AGray32(c::UInt32, ::Type{Val{true}}) = new(c)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,18 @@ using Test
 # Support pre- and post- julia #20288
 tformat(x...) = join(string.(x), ", ")
 
+# compatibility/regression tests for ARGB32 and AGray32
+@test ARGB32 <: AlphaColor{RGB24, N0f8, 4}
+@test ARGB32 <: AbstractARGB
+@test !(ARGB32 <: AbstractRGBA)
+@test AGray32 <: AlphaColor{Gray24, N0f8, 2}
+@test AGray32 <: AbstractAGray
+@test !(AGray32 <: AbstractGrayA)
+@test supertype(ARGB32) === AlphaColor{RGB24, N0f8, 4} # v0.9 or earlier
+@test supertype(ARGB32) === AbstractARGB{RGB24, N0f8}
+@test supertype(AGray32) === AlphaColor{Gray24, N0f8, 2} # v0.9 or earlier
+@test supertype(AGray32) === AbstractAGray{Gray24, N0f8}
+
 @test ColorTypes.to_top(AGray32(.8)) == ColorTypes.Colorant{FixedPointNumbers.Normed{UInt8,8},2}
 @test @inferred(eltype(Color{N0f8})) == N0f8
 @test @inferred(eltype(RGB{Float32})) == Float32


### PR DESCRIPTION
cf. https://github.com/JuliaGraphics/Colors.jl/issues/273#issuecomment-557839812

This also adds new type aliases `AbstractARGB`/`AbstractRGBA` for the consistency. (This does not add `AlphaColor3`/`ColorAlpha3`, though.)
`ARGB32` and `AGray32` are now defined with the new type aliases.