### PR TITLE
Work around JuliaLang/julia#34121 and Release 0.9.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ColorTypes"
 uuid = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
-version = "0.9.0"
+version = "0.9.1"
 
 [deps]
 FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"

--- a/src/ColorTypes.jl
+++ b/src/ColorTypes.jl
@@ -79,7 +79,9 @@ Concrete types:
 Use `?` to get more information about specific types or functions.
 """ ColorTypes
 
-include("precompile.jl")
-_precompile_()
+if VERSION >= v"1.1" # work around https://github.com/JuliaLang/julia/issues/34121
+    include("precompile.jl")
+    _precompile_()
+end
 
 end # module


### PR DESCRIPTION
I decided to add this workaround simply because it has already been added to FixedPointNumbers.jl and Colors.jl.
Until a specific problem with precompilation is discovered, the backporting to v0.8 (ie creating a branch) is pending.