### PR TITLE
add isless(a::AbstractGray, b::AbstractGray)

### DIFF
--- a/src/traits.jl
+++ b/src/traits.jl
@@ -385,3 +385,6 @@ function Base.one(::Type{C}) where {C<:Gray}
 end
 
 Base.broadcastable(x::Colorant) = Ref(x)
+
+Base.isless(a::AbstractGray, b::AbstractGray) =
+    isless(gray(a), gray(b))

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -594,6 +594,49 @@ end
     @test HSVA(100,0.4,0.6,0.8) ≈ HSVA{Float32}(100,0.4,0.6,0.8)
 end
 
+@testset "isless" begin
+    @test Gray(0.8) < Gray(0.9)
+    @test Gray(0.8) <= Gray(0.9)
+    @test Gray(0.9) <= Gray(0.9)
+    @test Gray(0.9) > Gray(0.8)
+    @test Gray(0.9) >= Gray(0.8)
+    @test Gray(0.9) >= Gray(0.9)
+
+    @test Gray(0.8f0) < Gray(0.9f0)
+    @test Gray(0.8f0) <= Gray(0.9f0)
+    @test Gray(0.9f0) <= Gray(0.9f0)
+    @test Gray(0.9f0) > Gray(0.8f0)
+    @test Gray(0.9f0) >= Gray(0.8f0)
+    @test Gray(0.9f0) >= Gray(0.9f0)
+
+    @test Gray(0.8N0f8) < Gray(0.9N0f8)
+    @test Gray(0.8N0f8) <= Gray(0.9N0f8)
+    @test Gray(0.9N0f8) <= Gray(0.9N0f8)
+    @test Gray(0.9N0f8) > Gray(0.8N0f8)
+    @test Gray(0.9N0f8) >= Gray(0.8N0f8)
+    @test Gray(0.9N0f8) >= Gray(0.9N0f8)
+
+    @test Gray(0.8) < Gray(0.9f0)
+    @test Gray(0.8) <= Gray(0.9f0)
+    # @test Gray(0.9) <= Gray(0.9f0) is not true due to approximation
+    @test Gray(0.9) > Gray(0.8f0)
+    @test Gray(0.9) >= Gray(0.8f0)
+    @test Gray(0.9) >= Gray(0.9f0)
+
+    @test Gray(0.8f0) < Gray(0.9N0f8)
+    @test Gray(0.8f0) <= Gray(0.9N0f8)
+    @test Gray(0.9f0) <= Gray(0.9N0f8)
+    @test Gray(0.9f0) > Gray(0.8N0f8)
+    @test Gray(0.9f0) >= Gray(0.8N0f8)
+    # @test Gray(0.9f0) >= Gray(0.9N0f8) is not true, since 0.9N0f8 = 0.902
+
+    # transparent gray doesn't support comparison
+    @test_throws MethodError GrayA(0.8, 0.4) < GrayA(0.9, 0.4)
+    @test_throws MethodError GrayA(0.8, 0.4) <= GrayA(0.9, 0.4)
+    @test_throws MethodError GrayA(0.9, 0.4) > GrayA(0.8, 0.4)
+    @test_throws MethodError GrayA(0.9, 0.4) >= GrayA(0.8, 0.4)
+end
+
 @testset "identities for Gray" begin
     @test oneunit(Gray{N0f8}) === Gray{N0f8}(1)
     @test zero(Gray{N0f8}) === Gray{N0f8}(0)


### PR DESCRIPTION
It's required by JuliaImages/ImageMorphology.jl#24 to support MaxTree-based operations in grayscale images.