### PR TITLE
Improve implementation of ccolor

### DIFF
--- a/src/ColorTypes.jl
+++ b/src/ColorTypes.jl
@@ -33,7 +33,7 @@ export RGB24, ARGB32, Gray24, AGray32
 
 
 ## Functions
-export base_color_type, base_colorant_type, ccolor, color, color_type
+export base_color_type, base_colorant_type, ccolor, color, color_type, parametric_colorant
 export alphacolor, coloralpha
 export alpha, red, green, blue, gray   # accessor functions that generalize to RGB24, etc.
 export chroma, hue

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -126,7 +126,7 @@ eltypes_supported(::Type{AGray32}) = N0f8
 eltypes_supported(c::Colorant) = eltypes_supported(typeof(c))
 
 """
-    issuported(C::Type, T::Type)::Bool
+    issupported(C::Type, T::Type)::Bool
 
 Returns `true` if `T` is a valid numeric eltype for `C<:Colorant`.
 """

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -109,83 +109,149 @@ to_top(::Type{Colorant{T,N}}) where {T,N} = Colorant{T,N}
 to_top(c::Colorant) = to_top(typeof(c))
 
 # eltype(RGB{Float32}) -> Float32
-eltype(::Type{Colorant{T}}) where {T          }   = T
-eltype(::Type{Colorant{T,N}}) where {T,N        } = T
+eltype(::Type{Colorant{T}}) where {T}       = T
+eltype(::Type{Colorant{T,N}}) where {T,N}   = T
 @pure eltype(::Type{C}) where {C<:Colorant} = eltype(supertype(C))
 
 eltype(c::Colorant) = eltype(typeof(c))
 
-# eltypes_supported(Colorant{T<:X}) -> T<:X (pre 0.6) or X (post 0.6)
+# eltypes_supported(Colorant{T<:X}) -> X
 @pure eltypes_supported(::Type{C}) where {C<:Colorant} =
     Base.parameter_upper_bound(base_colorant_type(C), 1)
+eltypes_supported(::Type{RGB24})   = N0f8
+eltypes_supported(::Type{Gray24})  = N0f8
+eltypes_supported(::Type{ARGB32})  = N0f8
+eltypes_supported(::Type{AGray32}) = N0f8
 
 eltypes_supported(c::Colorant) = eltypes_supported(typeof(c))
 
-@pure issupported(::Type{C}, ::Type{T}) where {C<:Colorant,T} = T <: eltypes_supported(C)
+"""
+    issuported(C::Type, T::Type)::Bool
+
+Returns `true` if `T` is a valid numeric eltype for `C<:Colorant`.
+"""
+issupported(::Type{C}, ::Type{T}) where {C<:Colorant,T} = T <: eltypes_supported(C)
 
 """
-`color_type(c)` or `color_type(C)` (`c` being a color instance and `C`
-being the type) returns the type of the Color object (without
-alpha channel).  This, and related functions like `base_color_type`,
-`base_colorant_type`, and `ccolor` are useful for manipulating types for
-writing generic code.
+    CT = color_type(C::Type)
+    CT = color_type(c::Colorant)
 
+Return the type of the Color object, discarding any alpha channel.
 For example,
 
-    color_type(RGB)          == RGB
-    color_type(RGB{Float32}) == RGB{Float32}
-    color_type(ARGB{N0f8})     == RGB{N0f8}
+    color_type(RGB)          === RGB
+    color_type(RGB{Float32}) === RGB{Float32}
+    color_type(ARGB{N0f8})   === RGB{N0f8}
+    color_type(RGB(1,0,0))   === RGB{N0f8}
+
+`color_type`, and related functions like [`base_color_type`](@ref),
+[`base_colorant_type`](@ref), and [`ccolor`](@ref) are useful for manipulating types
+when writing generic code.
 """
-color_type(::Type{TransparentColor})        = Color
 color_type(::Type{C}) where {C<:Color} = C
+color_type(::Type{C}) where {C<:AlphaColor} = color_type(supertype(C))
+color_type(::Type{C}) where {C<:ColorAlpha} = color_type(supertype(C))
+function color_type(::Type{TC}) where TC<:TransparentColor
+    _color_type(::Type{TC}) where TC<:TransparentColor{C, T} where {C,T} = C
+    return isa(TC, UnionAll) ? Base.parameter_upper_bound(TC, 1) : _color_type(TC)
+end
+
 color_type(c::Colorant) = color_type(typeof(c))
 
-# Return the number of components in the color
-# Note this is different from div(sizeof(c), sizeof(eltype(c))) (e.g., XRGB)
-length(c::Colorant) = length(typeof(c))
-
-length(::Type{C}) where C<:(Colorant{T,N} where T) where N = N
-# This definition should be unnecessary, but julia currently incorrectly
-# dispatches to the first definition below, even when the second is
-# applicable.
-_color_type(::Type{TC}) where TC<:(TransparentColor{C, T, N} where T where N) where C = C
-color_type(::Type{TC}) where TC<:TransparentColor =
-    isa(TC, UnionAll) ? Base.parameter_upper_bound(TC, 1) : _color_type(TC)
-color_type(::Type{TC}) where TC<:(TransparentColor{C, T, N} where T where N) where C = C
-
-@pure color_type(::Type{C}) where {C<:AlphaColor} = color_type(supertype(C))
-@pure color_type(::Type{C}) where {C<:ColorAlpha} = color_type(supertype(C))
-
 """
-`base_color_type` is similar to `color_type`, except it "strips off" the
-element type.  For example,
+    Cbase = base_color_type(C::Type)
+    Cbase = base_color_type(c::Colorant)
 
-    color_type(RGB{N0f8})     == RGB{N0f8}
-    base_color_type(RGB{N0f8}) == RGB
+Return the Color type without alpha channel or a specified numeric element type.
+`base_color_type` is similar to [`color_type`](@ref), except it "strips off" the
+element type. It always returns a parametric type, which makes it convenient
+for switching the numeric element type.
 
-This can be very handy if you want to switch element types. For example:
+For example, compare
+
+    base_color_type(RGB{N0f8})  === RGB
+    base_color_type(RGBA{N0f8}) === RGB
+
+vs
+
+    color_type(RGB{N0f8})       === RGB{N0f8}
+
+Switching element types can be done as follows:
 
     c64 = base_color_type(c){Float64}(color(c))
 
-converts `c` into a `Float64` representation (potentially discarding
-any alpha-channel information).
+`base_color_type` discards any alpha channel. See [`base_colorant_type`](@ref)
+if you want to preserve the alpha channel.
 """
 base_color_type(::Type{C}) where {C<:Colorant} = base_colorant_type(color_type(C))
+base_color_type(::Type{<:Number}) = Gray
 
-base_color_type(c::Colorant) = base_color_type(typeof(c))
-base_color_type(x::Number)   = Gray
+base_color_type(x::Union{Colorant,Number}) = base_color_type(typeof(x))
 
-@pure basetype(T) = Base.typename(T).wrapper
-base_colorant_type(::Type{C}) where {C<:Colorant} = basetype(C)
+## base_colorant_type implementation
+
+base_colorant_type(::Type{C}) where {C<:Colorant} = isabstracttype(C) ? abstract_basetype(C) : basetype(C)
+
+@pure basetype(@nospecialize(C)) = Base.typename(C).wrapper
+
+abstract_basetype(::Type{C}) where C  <: AbstractRGB       = AbstractRGB
+abstract_basetype(::Type{C}) where C  <: ColorN{N} where N = ColorN{N}
+abstract_basetype(::Type{Color})                           = Color
+abstract_basetype(::Type{C}) where C                       = abstract_transparent_basetype(C)  # separate function to control method ordering
+
+function abstract_transparent_basetype(::Type{AC}) where AC
+    AC<:AlphaColor && return alphacolor_basetype(AC)
+    AC<:ColorAlpha && return coloralpha_basetype(AC)
+    AC<:TransparentColor && return transparentcolor_basetype(AC)
+    return colorant_basetype(AC)
+end
+
+alphacolor_basetype(::Type{AC}) where AC <: AlphaColorN{N,C} where {N,C<:Color}  = AlphaColor{base_colorant_type(C){T},T,N} where T
+coloralpha_basetype(::Type{AC}) where AC <: ColorAlphaN{N,C} where {N,C<:Color}  = ColorAlpha{base_colorant_type(C){T},T,N} where T
+transparentcolor_basetype(::Type{AC}) where AC <: TransparentColorN{N,C} where {N,C<:Color} =
+    TransparentColor{base_colorant_type(C){T},T,N} where T
+transparentcolor_basetype(::Type{AC}) where AC <: TransparentColor               = TransparentColor
+colorant_basetype(::Type{C}) where C <: ColorantN{N} where N                     = ColorantN{N}
+colorant_basetype(::Type{C}) where C <: Colorant                                 = Colorant
+
+# These handle things like base_colorant_type(AbstractRGBA)
+function alphacolor_basetype(::Type{AC}) where AC <: AlphaColorN{N} where {N}
+    Cb = Base.parameter_upper_bound(AC, 1)
+    Cb === Color && return AlphaColor{C,T,N} where {T,C<:ColorN{N-1,T}}
+    return AlphaColor{C,T,N} where {T,C<:Cb{T}}
+end
+function coloralpha_basetype(::Type{AC}) where AC <: ColorAlphaN{N} where {N}
+    Cb = Base.parameter_upper_bound(AC, 1)
+    Cb === Color && return ColorAlpha{C,T,N} where {T,C<:ColorN{N-1,T}}
+    return ColorAlpha{C,T,N} where {T,C<:Cb{T}}
+end
+function transparentcolor_basetype(::Type{AC}) where AC <: TransparentColorN{N} where {N}
+    Cb = Base.parameter_upper_bound(AC, 1)
+    Cb === Color && return TransparentColor{C,T,N} where {T,C<:ColorN{N-1,T}}
+    return TransparentColor{C,T,N} where {T,C<:Cb{T}}
+end
+
+# # Ensure parametric return type
+# base_colorant_type(::Type{RGB24})   = RGB
+# base_colorant_type(::Type{Gray24})  = Gray
+# base_colorant_type(::Type{ARGB32})  = ARGB
+# base_colorant_type(::Type{AGray32}) = AGray
 
 """
-`base_colorant_type` is similar to `base_color_type`, but it preserves the
-"alpha" portion of the type.
+    Cbase = base_colorant_type(C::Type)
+    Cbase = base_colorant_type(c::Colorant)
 
-For example,
+Return the Colorant type without specified numeric element type.
+It always returns a parametric type, which makes it convenient for switching the numeric element type.
 
-    base_color_type(ARGB{N0f8})  == RGB
-    base_colorant_type(ARGB{N0f8})  == ARGB
+For example, compare
+
+    base_colorant_type(ARGB{N0f8}) === ARGB
+
+vs
+
+    base_color_type(ARGB{N0f8})    === RGB
+    color_type(ARGB{N0f8})         === RGB{N0f8}
 
 If you just want to switch element types, this is the safest default
 and the easiest to use:
@@ -237,85 +303,119 @@ showcoloranttype(io, ::Type{Union{}}) = show(io, Union{})
 showcoloranttype(io, ::Type{T}) where {T<:FixedPoint} = FixedPointNumbers.showtype(io, T)
 showcoloranttype(io, ::Type{T}) where {T} = show(io, T)
 
+@pure pureintersect(::Type{C1}, ::Type{C2}) where {C1,C2} = typeintersect(C1, C2)
 
 """
- `ccolor` ("concrete color") helps write flexible methods. The idea is
-that users may write `convert(HSV, c)` or even `convert(Array{HSV},
-A)` without specifying the element type explicitly (e.g.,
-`convert(Array{HSV{Float32}}, A)`). `ccolor` implements the logic "choose the
-user's eltype if specified, otherwise retain the eltype of the source
-object." However, when the source object has FixedPoint element type,
-and the destination only supports AbstractFloat, we choose Float32.
+    Calpha, Cbase, T = colorsplit(C)
 
-Usage:
+Split a color type `C` into three components: `T` is the numeric eltype,
+`Cbase` is the `base_color_type(C)`, and `wrap` is one of `identity`, `coloralpha`,
+or `alphacolor`.
+"""
+function colorsplit(::Type{C}) where C<:Colorant
+    Calpha = C <: AlphaColor ? AlphaColor :
+             C <: ColorAlpha ? ColorAlpha :
+             C <: Color ? Nothing :
+             C <: TransparentColor ? TransparentColor : Any
+    Cbase = C <: Union{Color,TransparentColor} ? base_color_type(C) : Color
+    return Calpha, Cbase, eltype(C)
+end
 
-    ccolor(desttype, srctype) -> concrete desttype
+"""
+    C = ccolor(Cdest, Csrc)
 
-Example:
+`ccolor` ("concrete color") supports independent selection of colorspace and
+numeric element type. `ccolor` chooses the numeric element type from
+`Cdest` if available, but if not specified gets it from `Csrc`.
 
-    convert{C<:Colorant}(::Type{C}, p::Colorant) = cnvt(ccolor(C,typeof(p)), p)
+```jldoctest
+julia> ccolor(RGB, Gray{Float32})
+RGB{Float32}
+
+julia> ccolor(RGB, Gray{N0f8})
+RGB{N0f8}
+
+julia> ccolor(RGB{Float32}, Gray{N0f8})
+RGB{Float32}
+```
+
+Some colorspaces don't support `FixedPoint` numeric element types;
+in such cases the `eltype_default` for `Cdest` is chosen:
+
+```jldoctest
+julia> ccolor(HSV, RGB{N0f8})
+HSV{Float32}
+```
+
+`Cdest` can be an abstract type, in which case `Csrc` must be in that
+abstract color space.
+
+```jldoctest
+julia> ccolor(Color{Float32}, RGB{N0f8})
+RGB{Float32}
+
+julia> ccolor(AbstractRGB{Float32}, BGR{N0f8})
+BGR{Float32}
+
+julia> ccolor(AbstractRGB{Float32}, HSV{Float32})
+ERROR: in ccolor, empty intersection between AbstractRGB and HSV
+Stacktrace:
+ [1] ccolor(::Type{AbstractRGB{Float32}}, ::Type{HSV{Float32}}) at /home/tim/.julia/dev/ColorTypes/src/traits.jl:344
+[...]
+```
+
+`ccolor` is most useful in defining other methods.
+For example, to allow users to write `convert(RGB, c)` without having to specify the
+numeric element type of `RGB`, define
+
+```
+convert(::Type{C}, p::Colorant) where C<:Colorant = cnvt(ccolor(C,typeof(p)), p)
+```
 
 where `cnvt` is the function that performs explicit conversion.
 """
-ccolor(::Type{Colorant   }, ::Type{Csrc}) where {   Csrc<:Colorant} = Csrc
-ccolor(::Type{Colorant{T}}, ::Type{Csrc}) where {T, Csrc<:Colorant} = base_colorant_type(Csrc){T}
-ccolor(::Type{Colorant{T,3}}, ::Type{Csrc}) where {T, Csrc<:Color3  } = Csrc
-ccolor(::Type{Colorant{T,3}}, ::Type{Csrc}) where {T, Csrc<:Transparent3} = base_color_type(Csrc)
-ccolor(::Type{Color   }, ::Type{Csrc}) where {   Csrc<:Colorant} = color_type(Csrc)
-ccolor(::Type{Color{T}}, ::Type{Csrc}) where {T, Csrc<:Colorant} = base_color_type(Csrc){T}
-
-ccolor(::Type{TransparentColor}, ::Type{Csrc}) where {Csrc<:Color} =
-          error("Ambiguous storage order, choose AlphaColor or ColorAlpha")
-ccolor(
-::Type{TransparentColor{C    }}, ::Type{Csrc}) where {C<:Color,    Csrc<:Color} =
-           error("Ambiguous storage order, choose AlphaColor or ColorAlpha")
-ccolor(
-::Type{TransparentColor{C,T  }}, ::Type{Csrc}) where {C<:Color,T,  Csrc<:Color} =
-           error("Ambiguous storage order, choose AlphaColor or ColorAlpha")
-ccolor(
-::Type{TransparentColor{C,T,N}}, ::Type{Csrc}) where {C<:Color,T,N,Csrc<:Color} =
-           error("Ambiguous storage order, choose AlphaColor or ColorAlpha")
-
-ccolor(::Type{TransparentColor}, ::Type{Csrc}) where {Csrc<:TransparentColor} = Csrc
-
-ccolor(::Type{AlphaColor}, ::Type{Csrc}) where {Csrc<:Colorant} = alphacolor(Csrc)
-ccolor(
-::Type{AlphaColor{C    }}, ::Type{Csrc}) where {C<:Color,    Csrc<:Colorant} = ccolor(alphacolor(C), Csrc)
-ccolor(
-::Type{AlphaColor{C,T  }}, ::Type{Csrc}) where {C<:Color,T,  Csrc<:Colorant} = ccolor(alphacolor(C){T}, Csrc)
-ccolor(
-::Type{AlphaColor{C,T,N}}, ::Type{Csrc}) where {C<:Color,T,N,Csrc<:Colorant} = ccolor(alphacolor(C){T}, Csrc)
-
-ccolor(::Type{ColorAlpha}, ::Type{Csrc}) where {Csrc<:Colorant} = coloralpha(Csrc)
-ccolor(
-::Type{ColorAlpha{C    }}, ::Type{Csrc}) where {C<:Color,    Csrc<:Colorant} = ccolor(coloralpha(C), Csrc)
-ccolor(
-::Type{ColorAlpha{C,T  }}, ::Type{Csrc}) where {C<:Color,T,  Csrc<:Colorant} = ccolor(coloralpha(C){T}, Csrc)
-ccolor(
-::Type{ColorAlpha{C,T,N}}, ::Type{Csrc}) where {C<:Color,T,N,Csrc<:Colorant} = ccolor(coloralpha(C){T}, Csrc)
-
-ccolor(::Type{AbstractRGB},    ::Type{Csrc}) where {  Csrc<:AbstractRGB} = Csrc
-ccolor(::Type{AbstractRGB{T}}, ::Type{Csrc}) where {T,Csrc<:AbstractRGB} = base_colorant_type(Csrc){T}
-
-# Generic concrete types
-ccolor(::Type{Cdest}, ::Type{Csrc}) where {Cdest<:Colorant,Csrc<:Colorant} = _ccolor(Cdest, Csrc, pick_eltype(Cdest, eltype(Cdest), eltype(Csrc)))
-ccolor(::Type{Cdest}, ::Type{T}) where {Cdest<:AbstractGray,T<:Number} = _ccolor(Cdest, Gray, pick_eltype(Cdest, eltype(Cdest), T))
-
-_ccolor(::Type{Cdest}, ::Type{Csrc}, ::Type{T}) where {Cdest,Csrc,T<:Number} =
-    isconcretetype(T) ? base_colorant_type(Cdest){T} :
-                    base_colorant_type(Cdest){S} where S<:T
-
-_ccolor(          ::Type{Cdest}, ::Type{Csrc}, ::Any) where {Cdest,Csrc}     = Cdest
-
-# Specific concrete types
-ccolor(::Type{RGB24},   ::Type{Csrc}) where {Csrc<:Colorant} = RGB24
-ccolor(::Type{ARGB32},  ::Type{Csrc}) where {Csrc<:Colorant} = ARGB32
-ccolor(::Type{Gray24},  ::Type{Csrc}) where {Csrc<:Colorant} = Gray24
-ccolor(::Type{AGray32}, ::Type{Csrc}) where {Csrc<:Colorant} = AGray32
-
-pick_eltype(::Type{C}, ::Type{T1}, ::Type{T2}) where {C,T1<:Number,T2<:Number} = T1
-pick_eltype(::Type{C}, ::Any, ::Any) where {C} = eltypes_supported(C)
-pick_eltype(::Type{C}, ::Any, ::Type{T2}) where {C,T2<:Number} = issupported(C, T2) ? T2 : eltype_default(C)
+function ccolor(::Type{Cdest}, ::Type{Csrc}) where {Cdest<:Colorant, Csrc<:Union{Number,Colorant}}
+    Cdestalpha, Cdestbase, Tdest = colorsplit(Cdest)
+    if Csrc <: Number
+        Csrcalpha, Csrcbase, Tsrc = Any, Color, Csrc
+    else
+        Csrcalpha, Csrcbase, Tsrc = colorsplit(Csrc)
+    end
+    # Step 1: pick the base color type
+    if isabstracttype(Cdestbase)
+        C = pureintersect(Cdestbase, Csrcbase)
+        C === Union{} && throw(TwoColorTypeError(:ccolor, "empty intersection between", Cdestbase, Csrcbase))
+        isabstracttype(C) && throw(TwoColorTypeError(:ccolor, "abstract intersection between", Cdestbase, Csrcbase))
+    else
+        C = Cdestbase
+    end
+    # Step 2: combine with the alpha representation
+    if Cdestalpha === Nothing
+    else
+        Calpha = (Cdestalpha === TransparentColor || Cdestalpha === Any) ? Csrcalpha : Cdestalpha
+        Cdestalpha === TransparentColor && Calpha === Nothing && throw(TwoColorTypeError(:ccolor, "ambiguous alpha storage between", Cdest, Csrc))
+        if Calpha !== Nothing
+            Calpha === TransparentColor && throw(TwoColorTypeError(:ccolor, "ambiguous alpha storage between", Cdest, Csrc))
+            C = Calpha <: AlphaColor ? alphacolor(C) :
+                Calpha <: ColorAlpha ? coloralpha(C) : error("unexpected Calpha ", Calpha)
+        end
+    end
+    # Step 3: assign the eltype
+    if !isa(C, UnionAll)
+        eltype(C) <: Tdest && return C   # RGB24 etc.
+        error("nonparametric type ", C, " has ambiguous destination ", Cdest)
+    end
+    isabstracttype(Tdest) || !issupported(C, Tdest) || return C{Tdest}
+    T = pureintersect(Tdest, Tsrc)
+    T === Union{} && throw(TwoColorTypeError(:ccolor, "empty intersection between", Tdest, Tsrc))
+    T === Any && return C
+    Tdef = eltype_default(C)
+    issupported(C, T) && return C{T}
+    T<:Integer && return C{Tdef}
+    Tf = floattype(Tsrc)
+    issupported(C, Tf) && return C{Tf}
+    return C{Tdef}
+end
 
 ### Equality
 function ==(c1::AbstractRGB, c2::AbstractRGB)

--- a/src/types.jl
+++ b/src/types.jl
@@ -23,7 +23,7 @@ assumptions about internal storage order, the number of fields, or the
 representation. One `AbstractRGB` color-type, `RGB24`, is not
 parametric and does not have fields named `r`, `g`, `b`.
 """
-abstract type AbstractRGB{T}      <: Color{T,3} end
+abstract type AbstractRGB{T} <: Color{T,3} end
 
 
 # Types with transparency
@@ -56,13 +56,13 @@ abstract type TransparentColor{C<:Color,T,N} <: Colorant{T,N} end
 alpha channel comes first in the internal storage order. **Note** that
 the constructor order is still `(color, alpha)`.
 """
-abstract type AlphaColor{C,T,N} <: TransparentColor{C,T,N} end
+abstract type AlphaColor{C<:Color,T,N} <: TransparentColor{C,T,N} end
 
 """
 `ColorAlpha` is an abstract supertype for types like `RGBA`, where the
 alpha channel comes last in the internal storage order.
 """
-abstract type ColorAlpha{C,T,N} <: TransparentColor{C,T,N} end
+abstract type ColorAlpha{C<:Color,T,N} <: TransparentColor{C,T,N} end
 
 # These are types we'll dispatch on.
 AbstractGray{T}                    = Color{T,1}
@@ -75,6 +75,13 @@ AbstractAGray{C<:AbstractGray,T}   = AlphaColor{C,T,2}
 AbstractGrayA{C<:AbstractGray,T}   = ColorAlpha{C,T,2}
 AbstractARGB{C<:AbstractRGB,T}     = AlphaColor{C,T,4}
 AbstractRGBA{C<:AbstractRGB,T}     = ColorAlpha{C,T,4}
+
+# With reordered type parameters (also useful for dispatch)
+ColorantN{N,T}                  = Colorant{T,N}
+ColorN{N,T}                     = Color{T,N}
+TransparentColorN{N,C<:Color,T} = TransparentColor{C,T,N}
+AlphaColorN{N,C<:Color,T}       = AlphaColor{C,T,N}
+ColorAlphaN{N,C<:Color,T}       = ColorAlpha{C,T,N}
 
 """
 `RGB` is the standard Red-Green-Blue (sRGB) colorspace.  Values of the
@@ -414,15 +421,22 @@ AGray32(g::AbstractGray, alpha = 1) = AGray32(gray(g), alpha)
 # Note: with the exceptions of `alphacolor` and `coloralpha`, all
 # traits in the rest of this file are intended just for internal use
 
+# The following should be in traits.jl but we need it now.
+# Return the number of components in the color
+# Note this is different from div(sizeof(c), sizeof(eltype(c))) (e.g., XRGB)
+length(c::Colorant) = length(typeof(c))
+length(::Type{C}) where C<:(Colorant{T,N} where T) where N = N
+
 const color3types = map(s->getfield(ColorTypes,s),
-  filter(names(ColorTypes, all=false)) do s
-    isdefined(ColorTypes, s) || return false
-    t = getfield(ColorTypes, s)
-    isa(t, Type) && t <: Colorant && !isabstracttype(t) && length(fieldnames(t))>1
-  end)
+                        filter(names(ColorTypes, all=false)) do s
+                            isdefined(ColorTypes, s) || return false
+                            t = getfield(ColorTypes, s)
+                            isa(t, Type) && t <: Color && !isabstracttype(t) && length(t) == 3
+                        end
+                        )
+
 # The above should have filtered out every non-DataType that's not also a
-# wrapped UnionAll-wrapped DataType. By avoiding the explicit UnionAll check
-# here, we remain compatible with pre-0.6 julia.
+# wrapped UnionAll-wrapped DataType.
 const parametric3 = filter(x->!isa(x, DataType) || !isempty(x.parameters), color3types)
 
 # Provide the field names in the order expected by the constructor
@@ -694,3 +708,14 @@ end
 
 _rem(x,::Type{T}) where {T<:Normed} = x % T
 _rem(x, ::Type{T}) where {T}        = x
+
+struct TwoColorTypeError <: Exception
+    func::Symbol
+    msg::String
+    C1
+    C2
+end
+
+function Base.showerror(io::IO, ex::TwoColorTypeError)
+    print(io, "in ", ex.func, ", ", ex.msg, ' ', ex.C1, " and ", ex.C2)
+end

--- a/src/types.jl
+++ b/src/types.jl
@@ -431,8 +431,8 @@ const color3types = map(s->getfield(ColorTypes,s),
                         filter(names(ColorTypes, all=false)) do s
                             isdefined(ColorTypes, s) || return false
                             t = getfield(ColorTypes, s)
-                            isa(t, Type) && t <: Color && !isabstracttype(t) && length(t) == 3
-                        end
+                            isa(t, Type{<:Color3}) && !isabstracttype(t)
+                        end |> unique
                         )
 
 # The above should have filtered out every non-DataType that's not also a
@@ -709,13 +709,13 @@ end
 _rem(x,::Type{T}) where {T<:Normed} = x % T
 _rem(x, ::Type{T}) where {T}        = x
 
-struct TwoColorTypeError <: Exception
+struct ColorTypeResolutionError <: Exception
     func::Symbol
     msg::String
     C1
     C2
 end
 
-function Base.showerror(io::IO, ex::TwoColorTypeError)
+function Base.showerror(io::IO, ex::ColorTypeResolutionError)
     print(io, "in ", ex.func, ", ", ex.msg, ' ', ex.C1, " and ", ex.C2)
 end

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -1,6 +1,6 @@
 using ColorTypes, FixedPointNumbers
 using Test
-using ColorTypes: TwoColorTypeError
+using ColorTypes: ColorTypeResolutionError
 
 @testset "rgb promotions" begin
     @test        promote( RGB{N0f8}(0.2,0.3,0.4),  RGB(0.3,0.8,0.1)) === ( RGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8),  RGB{Float64}(0.3,0.8,0.1))
@@ -133,10 +133,10 @@ end
     @test convert(Color{Float32}, c) === RGB{Float32}(1, 0.6, 0)
     @test convert(AbstractRGB, c) === RGB{Float64}(1, 0.6, 0)
     @test convert(AbstractRGB{N0f8}, c) === RGB{N0f8}(1, 0.6, 0)
-    @test_throws TwoColorTypeError convert(TransparentColor, c)
-    @test_throws TwoColorTypeError convert(TransparentColor{RGB{N0f8}}, c)
-    @test_throws TwoColorTypeError convert(TransparentColor{RGB{N0f8},N0f8}, c)
-    @test_throws TwoColorTypeError convert(TransparentColor{RGB{N0f8},N0f8,2}, c)
+    @test_throws ColorTypeResolutionError convert(TransparentColor, c)
+    @test_throws ColorTypeResolutionError convert(TransparentColor{RGB{N0f8}}, c)
+    @test_throws ColorTypeResolutionError convert(TransparentColor{RGB{N0f8},N0f8}, c)
+    @test_throws ColorTypeResolutionError convert(TransparentColor{RGB{N0f8},N0f8,2}, c)
     @test convert(AlphaColor, c) === ARGB{Float64}(1, 0.6, 0, 1)
     @test_broken convert(AlphaColor{RGB{N0f8}}, c) === ARGB{N0f8}(1, 0.6, 0, 1)
     @test convert(AlphaColor{RGB{N0f8},N0f8}, c) === ARGB{N0f8}(1, 0.6, 0, 1)
@@ -175,7 +175,7 @@ end
     @test convert(Color, rgb24) === RGB24(1, 0.6, 0)
     @test convert(AbstractRGB, rgb24) === RGB24(1, 0.6, 0)
     @test convert(AbstractRGB{N0f8}, rgb24) === RGB24(1, 0.6, 0)
-    @test_throws TwoColorTypeError convert(TransparentColor, rgb24)
+    @test_throws ColorTypeResolutionError convert(TransparentColor, rgb24)
     @test convert(AlphaColor, rgb24) === ARGB32(1, 0.6, 0, 1)
     @test_throws MethodError convert(ColorAlpha, rgb24)
 
@@ -205,7 +205,7 @@ end
     @test convert(Colorant{N0f8}, c) === Gray{N0f8}(0.4)
     @test convert(Colorant{Float32,1}, c) === Gray{Float32}(0.4)
     @test convert(Color, c) === Gray{Float64}(0.4)
-    @test_throws TwoColorTypeError convert(TransparentColor, c)
+    @test_throws ColorTypeResolutionError convert(TransparentColor, c)
     @test convert(AlphaColor, c) === AGray{Float64}(0.4, 1)
     @test convert(ColorAlpha, c) === GrayA{Float64}(0.4, 1)
 
@@ -232,7 +232,7 @@ end
     @test convert(Colorant{N0f8}, gray24) === Gray24(0.4)
     @test_broken convert(Colorant{Float32,1}, gray24) === Gray{Float32}(0.4)
     @test convert(Color, gray24) === Gray24(0.4)
-    @test_throws TwoColorTypeError convert(TransparentColor, gray24)
+    @test_throws ColorTypeResolutionError convert(TransparentColor, gray24)
     @test convert(AlphaColor, gray24) === AGray32(0.4, 1)
     @test_throws MethodError convert(ColorAlpha, gray24) # TODO: need docs
 
@@ -288,9 +288,9 @@ end
     @test convert(AGray32, 0.6, 0.8) === AGray32(0.6, 0.8)
     @test convert(AGray32, 0, 1) === AGray32(0, 1)
 
-    @test_throws TwoColorTypeError convert(Colorant, 0.6)
-    @test_throws TwoColorTypeError convert(Color, 0.6)
-    @test_throws TwoColorTypeError convert(Color{N0f8,1}, 0.6)
+    @test_throws ColorTypeResolutionError convert(Colorant, 0.6)
+    @test_throws ColorTypeResolutionError convert(Color, 0.6)
+    @test_throws ColorTypeResolutionError convert(Color{N0f8,1}, 0.6)
 
     @test_throws MethodError convert(GrayA, 0.6, 0.8)
     @test_throws MethodError convert(AGray, 0, 1)

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -1,5 +1,6 @@
 using ColorTypes, FixedPointNumbers
 using Test
+using ColorTypes: TwoColorTypeError
 
 @testset "rgb promotions" begin
     @test        promote( RGB{N0f8}(0.2,0.3,0.4),  RGB(0.3,0.8,0.1)) === ( RGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8),  RGB{Float64}(0.3,0.8,0.1))
@@ -126,16 +127,16 @@ end
     c = RGB(1, 0.6, 0)
     @test convert(Colorant, c) === RGB{Float64}(1, 0.6, 0)
     @test convert(Colorant{N0f8}, c) === RGB{N0f8}(1, 0.6, 0)
-    @test_broken convert(Colorant{Float32,3}, c) === RGB{Float32}(1, 0.6, 0)
+    @test convert(Colorant{Float32,3}, c) === RGB{Float32}(1, 0.6, 0)
     @test convert(Color, c) === RGB{Float64}(1, 0.6, 0)
     @test convert(Color{N0f8}, c) === RGB{N0f8}(1, 0.6, 0)
     @test convert(Color{Float32}, c) === RGB{Float32}(1, 0.6, 0)
     @test convert(AbstractRGB, c) === RGB{Float64}(1, 0.6, 0)
     @test convert(AbstractRGB{N0f8}, c) === RGB{N0f8}(1, 0.6, 0)
-    @test_throws ErrorException convert(TransparentColor, c)
-    @test_throws ErrorException convert(TransparentColor{RGB{N0f8}}, c)
-    @test_throws ErrorException convert(TransparentColor{RGB{N0f8},N0f8}, c)
-    @test_throws ErrorException convert(TransparentColor{RGB{N0f8},N0f8,2}, c)
+    @test_throws TwoColorTypeError convert(TransparentColor, c)
+    @test_throws TwoColorTypeError convert(TransparentColor{RGB{N0f8}}, c)
+    @test_throws TwoColorTypeError convert(TransparentColor{RGB{N0f8},N0f8}, c)
+    @test_throws TwoColorTypeError convert(TransparentColor{RGB{N0f8},N0f8,2}, c)
     @test convert(AlphaColor, c) === ARGB{Float64}(1, 0.6, 0, 1)
     @test_broken convert(AlphaColor{RGB{N0f8}}, c) === ARGB{N0f8}(1, 0.6, 0, 1)
     @test convert(AlphaColor{RGB{N0f8},N0f8}, c) === ARGB{N0f8}(1, 0.6, 0, 1)
@@ -150,8 +151,8 @@ end
     @test convert(Colorant{N0f8}, ac) === ARGB{N0f8}(1, 0.6, 0, 0.8)
     @test_broken convert(Colorant{Float32,3}, ac) === RGB{Float32}(1, 0.6, 0)
     @test convert(Color, ac) === RGB{Float64}(1, 0.6, 0)
-    @test_broken convert(AbstractRGB, ac) === RGB{Float64}(1, 0.6, 0)
-    @test_broken convert(AbstractRGB{N0f8}, ac) === RGB{N0f8}(1, 0.6, 0)
+    @test convert(AbstractRGB, ac) === RGB{Float64}(1, 0.6, 0)
+    @test convert(AbstractRGB{N0f8}, ac) === RGB{N0f8}(1, 0.6, 0)
     @test convert(TransparentColor, ac) == ARGB{Float64}(1, 0.6, 0, 0.8)
     @test convert(AlphaColor, ac) === ARGB{Float64}(1, 0.6, 0, 0.8) # issue #126
     @test convert(ColorAlpha, ac) === RGBA{Float64}(1, 0.6, 0, 0.8) # issue #126
@@ -161,8 +162,8 @@ end
     @test convert(Colorant{N0f8}, ca) === RGBA{N0f8}(1, 0.6, 0, 0.8)
     @test_broken convert(Colorant{Float32,3}, ca) === RGB{Float32}(1, 0.6, 0)
     @test convert(Color, ca) === RGB{Float64}(1, 0.6, 0)
-    @test_broken convert(AbstractRGB, ca) === RGB{Float64}(1, 0.6, 0)
-    @test_broken convert(AbstractRGB{N0f8}, ca) === RGB{N0f8}(1, 0.6, 0)
+    @test convert(AbstractRGB, ca) === RGB{Float64}(1, 0.6, 0)
+    @test convert(AbstractRGB{N0f8}, ca) === RGB{N0f8}(1, 0.6, 0)
     @test convert(TransparentColor, ca) == RGBA{Float64}(1, 0.6, 0, 0.8)
     @test convert(AlphaColor, ca) === ARGB{Float64}(1, 0.6, 0, 0.8) # issue #126
     @test convert(ColorAlpha, ca) === RGBA{Float64}(1, 0.6, 0, 0.8) # issue #126
@@ -174,7 +175,7 @@ end
     @test convert(Color, rgb24) === RGB24(1, 0.6, 0)
     @test convert(AbstractRGB, rgb24) === RGB24(1, 0.6, 0)
     @test convert(AbstractRGB{N0f8}, rgb24) === RGB24(1, 0.6, 0)
-    @test_throws ErrorException convert(TransparentColor, rgb24)
+    @test_throws TwoColorTypeError convert(TransparentColor, rgb24)
     @test convert(AlphaColor, rgb24) === ARGB32(1, 0.6, 0, 1)
     @test_throws MethodError convert(ColorAlpha, rgb24)
 
@@ -183,15 +184,15 @@ end
     @test convert(Colorant{N0f8}, argb32) === ARGB32(1, 0.6, 0, 0.8)
     @test_broken convert(Colorant{Float32,3}, argb32) === RGB{Float32}(1, 0.6, 0)
     @test convert(Color, argb32) === RGB24(1, 0.6, 0)
-    @test_broken convert(AbstractRGB, argb32) === RGB24(1, 0.6, 0)
-    @test_broken convert(AbstractRGB{N0f8}, argb32) === RGB24(1, 0.6, 0)
+    @test convert(AbstractRGB, argb32) === RGB24(1, 0.6, 0)
+    @test convert(AbstractRGB{N0f8}, argb32) === RGB24(1, 0.6, 0)
     @test convert(TransparentColor, argb32) === ARGB32(1, 0.6, 0, 0.8)
     @test convert(AlphaColor, argb32) === ARGB32(1, 0.6, 0, 0.8)
     @test_throws MethodError convert(ColorAlpha, argb32)
 
     @test convert(AbstractARGB{RGB,N0f8}, c, 0.2) === ARGB{N0f8}(1, 0.6, 0, 0.2)
     @test convert(AbstractRGBA{RGB,N0f8}, c, 0.2) === RGBA{N0f8}(1, 0.6, 0, 0.2)
-    @test_broken convert(AbstractARGB{RGB24,N0f8}, rgb24, 0.2) === ARGB32(1, 0.6, 0, 0.2)
+    @test convert(AbstractARGB{RGB24,N0f8}, rgb24, 0.2) === ARGB32(1, 0.6, 0, 0.2)
     @test_throws MethodError convert(AbstractARGB{RGB,N0f8}, ac, 0.2)
     @test_throws MethodError convert(AbstractARGB{RGB,N0f8}, ca, 0.2)
     @test_throws ErrorException convert(AbstractARGB{RGB,N0f8}, rgb24, 0.2)
@@ -202,9 +203,9 @@ end
     c = Gray(0.4)
     @test convert(Colorant, c) === Gray{Float64}(0.4)
     @test convert(Colorant{N0f8}, c) === Gray{N0f8}(0.4)
-    @test_broken convert(Colorant{Float32,1}, c) === Gray{Float32}(0.4)
+    @test convert(Colorant{Float32,1}, c) === Gray{Float32}(0.4)
     @test convert(Color, c) === Gray{Float64}(0.4)
-    @test_throws ErrorException convert(TransparentColor, c)
+    @test_throws TwoColorTypeError convert(TransparentColor, c)
     @test convert(AlphaColor, c) === AGray{Float64}(0.4, 1)
     @test convert(ColorAlpha, c) === GrayA{Float64}(0.4, 1)
 
@@ -231,7 +232,7 @@ end
     @test convert(Colorant{N0f8}, gray24) === Gray24(0.4)
     @test_broken convert(Colorant{Float32,1}, gray24) === Gray{Float32}(0.4)
     @test convert(Color, gray24) === Gray24(0.4)
-    @test_throws ErrorException convert(TransparentColor, gray24)
+    @test_throws TwoColorTypeError convert(TransparentColor, gray24)
     @test convert(AlphaColor, gray24) === AGray32(0.4, 1)
     @test_throws MethodError convert(ColorAlpha, gray24) # TODO: need docs
 
@@ -248,7 +249,7 @@ end
     @test convert(AbstractGrayA{Gray,N0f8}, c, 0.2) === GrayA{N0f8}(0.4, 0.2)
     # the following is ok, but not consistent with the case of RGB24
     @test convert(AbstractAGray{Gray,N0f8}, gray24, 0.2) === AGray{N0f8}(0.4, 0.2)
-    @test_broken convert(AbstractAGray{Gray24,N0f8}, gray24, 0.2) === AGray32(0.4, 0.2)
+    @test convert(AbstractAGray{Gray24,N0f8}, gray24, 0.2) === AGray32(0.4, 0.2)
     @test_throws MethodError convert(AbstractAGray{Gray,N0f8}, ac, 0.2)
     @test_throws MethodError convert(AbstractAGray{Gray,N0f8}, ca, 0.2)
     @test_throws MethodError convert(AbstractAGray{Gray,N0f8}, agray32, 0.2)
@@ -287,9 +288,9 @@ end
     @test convert(AGray32, 0.6, 0.8) === AGray32(0.6, 0.8)
     @test convert(AGray32, 0, 1) === AGray32(0, 1)
 
-    @test_throws MethodError convert(Colorant, 0.6)
-    @test_throws MethodError convert(Color, 0.6)
-    @test_throws ErrorException convert(Color{N0f8,1}, 0.6)
+    @test_throws TwoColorTypeError convert(Colorant, 0.6)
+    @test_throws TwoColorTypeError convert(Color, 0.6)
+    @test_throws TwoColorTypeError convert(Color{N0f8,1}, 0.6)
 
     @test_throws MethodError convert(GrayA, 0.6, 0.8)
     @test_throws MethodError convert(AGray, 0, 1)
@@ -300,7 +301,7 @@ end
     @test convert(RGB24, 0.6) === RGB24(0.6, 0.6, 0.6)
     @test convert(ARGB32, 0.6) === ARGB32(0.6, 0.6, 0.6, 1)
 
-    @test_throws MethodError convert(RGB, 0.6)
+    @test convert(RGB, 0.6) === RGB(0.6, 0.6, 0.6)
 end
 
 @testset "conversions from rgb to rgb" begin

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -1,6 +1,6 @@
 using ColorTypes, FixedPointNumbers
 using Test
-using ColorTypes: TwoColorTypeError
+using ColorTypes: ColorTypeResolutionError
 
 @testset "RGB accessors" begin
 
@@ -409,13 +409,23 @@ end
     @test_throws MethodError ColorTypes.colorant_string_with_eltype(Float32)
 end
 
+@testset "parametric_colorant" begin
+    @test parametric_colorant(RGB{Float32}) === RGB{Float32}
+    @test parametric_colorant(RGB)          === RGB
+    @test parametric_colorant(BGR{Float32}) === BGR{Float32}
+    @test parametric_colorant(RGB24)        === RGB{N0f8}
+    @test parametric_colorant(Gray24)       === Gray{N0f8}
+    @test parametric_colorant(ARGB32)       === ARGB{N0f8}
+    @test parametric_colorant(AGray32)      === AGray{N0f8}
+end
+
 @testset "ccolor" begin
     @test @inferred(ccolor(Colorant, XRGB{N0f8})) === XRGB{N0f8}
     @test @inferred(ccolor(Colorant{N0f8}, RGBX{Float32})) === RGBX{N0f8}
     @test @inferred(ccolor(Colorant{N0f8,3}, BGR{N0f8})) === BGR{N0f8}
 
-    @test_throws TwoColorTypeError ccolor(AbstractRGB, HSV{Float32})
-    @test_throws TwoColorTypeError ccolor(AbstractRGB{N0f8}, HSV{Float32})
+    @test_throws ColorTypeResolutionError ccolor(AbstractRGB, HSV{Float32})
+    @test_throws ColorTypeResolutionError ccolor(AbstractRGB{N0f8}, HSV{Float32})
     @test @inferred(ccolor(AbstractRGB, RGB24)) === RGB24
     @test_throws ErrorException ccolor(AbstractRGB{Float32}, RGB24)
 
@@ -448,6 +458,13 @@ end
     @test @inferred(ccolor(Gray, Int)) === Gray{N0f8}
     @test @inferred(ccolor(Gray, Float32)) === Gray{Float32}
 
+    @test @inferred(ccolor(RGB{N0f8}, Bool)) === RGB{N0f8}
+    @test_broken @inferred(ccolor(RGB, Bool)) === RGB{Bool}
+    @test @inferred(ccolor(RGB, Int)) === RGB{N0f8}
+    @test @inferred(ccolor(RGB, Float32)) === RGB{Float32}
+
+    @test_throws ColorTypeResolutionError ccolor(HSV, Int)
+
     @test @inferred(ccolor(RGB24, HSV{Float32})) === RGB24
     @test @inferred(ccolor(ARGB32, HSV{Float32})) === ARGB32
     @test @inferred(ccolor(Gray24, HSV{Float32})) === Gray24
@@ -461,11 +478,11 @@ end
     @test @inferred(ccolor(TransparentColor, AHSV{Float32})) === AHSV{Float32}
 
     # Ambiguous storage order, choose AlphaColor or ColorAlpha
-    @test_throws TwoColorTypeError ccolor(TransparentColor, HSV{Float32})
-    @test_throws TwoColorTypeError ccolor(TransparentColor{RGB}, HSV{Float32})
-    @test_throws TwoColorTypeError ccolor(TransparentColor{RGB,Float64}, HSV{Float32})
-    @test_throws TwoColorTypeError ccolor(TransparentColor{RGB{Float64},Float64}, HSV{Float32})
-    @test_throws TwoColorTypeError ccolor(TransparentColor{RGB{Float64},Float64,4}, HSV{Float32})
+    @test_throws ColorTypeResolutionError ccolor(TransparentColor, HSV{Float32})
+    @test_throws ColorTypeResolutionError ccolor(TransparentColor{RGB}, HSV{Float32})
+    @test_throws ColorTypeResolutionError ccolor(TransparentColor{RGB,Float64}, HSV{Float32})
+    @test_throws ColorTypeResolutionError ccolor(TransparentColor{RGB{Float64},Float64}, HSV{Float32})
+    @test_throws ColorTypeResolutionError ccolor(TransparentColor{RGB{Float64},Float64,4}, HSV{Float32})
 
     @test @inferred(ccolor(AlphaColor, RGB)) === ARGB
     @test @inferred(ccolor(AlphaColor, RGB{N0f8})) === ARGB{N0f8}

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -1,5 +1,6 @@
 using ColorTypes, FixedPointNumbers
 using Test
+using ColorTypes: TwoColorTypeError
 
 @testset "RGB accessors" begin
 
@@ -275,12 +276,12 @@ end
     @test @inferred(base_color_type(AbstractARGB{RGB{Float64},Float64})) === RGB
     @test @inferred(base_color_type(TransparentRGB)) === AbstractRGB
 
-    @test_broken @inferred(base_color_type(AbstractGrayA)) === AbstractGray
-    @test_broken @inferred(base_color_type(AbstractAGray)) === AbstractGray
-    @test_broken @inferred(base_color_type(TransparentGray)) === AbstractGray
+    @test @inferred(base_color_type(AbstractGrayA)) === AbstractGray
+    @test @inferred(base_color_type(AbstractAGray)) === AbstractGray
+    @test @inferred(base_color_type(TransparentGray)) === AbstractGray
 
-    @test_broken @inferred(base_color_type(Color3)) === Color3
-    @test_broken @inferred(base_color_type(Transparent3)) === Color3
+    @test @inferred(base_color_type(Color3)) === Color3
+    @test @inferred(base_color_type(Transparent3)) === Color3
     @test @inferred(base_color_type(Color)) === Color
     @test @inferred(base_color_type(TransparentColor)) === Color
     @test @inferred(base_color_type(TransparentColor{RGB})) === RGB
@@ -288,7 +289,7 @@ end
     @test @inferred(base_color_type(TransparentColor{RGB{Float64},Float64})) === RGB
     @test_throws MethodError color_type(Colorant{N0f8})
 
-    @test_broken base_color_type(N0f8) === Gray
+    @test base_color_type(N0f8) === Gray
 
     # for instances
     @test @inferred(base_color_type(RGB{N0f8}(1,0,0))) === RGB
@@ -329,24 +330,19 @@ end
     @test @inferred(base_colorant_type(AHSV{Float64})) === AHSV
 
     @test @inferred(base_colorant_type(AbstractRGB)) === AbstractRGB
-    @test @inferred(base_colorant_type(AbstractRGBA)) === ColorAlpha # FIXME
-    @test @inferred(base_colorant_type(AbstractARGB)) === AlphaColor # FIXME
-    @test_broken @inferred(base_colorant_type(AbstractRGBA)) === AbstractRGBA
-    @test_broken @inferred(base_colorant_type(AbstractARGB)) === AbstractARGB
+    @test @inferred(base_colorant_type(AbstractRGBA)) === ColorAlpha{C,T,4} where C<:AbstractRGB{T} where T
+    @test @inferred(base_colorant_type(AbstractARGB)) === AlphaColor{C,T,4} where C<:AbstractRGB{T} where T
     @test @inferred(base_colorant_type(AbstractRGB{N0f8})) === AbstractRGB
-    @test @inferred(base_colorant_type(AbstractRGBA{RGB,Float32})) === ColorAlpha # FIXME
-    @test @inferred(base_colorant_type(AbstractARGB{RGB{Float64},Float64})) === AlphaColor # FIXME
-    @test_broken @inferred(base_colorant_type(AbstractRGBA{RGB,Float32})) === RGBA
-    @test_broken @inferred(base_colorant_type(AbstractARGB{RGB{Float64},Float64})) === ARGB
-    @test @inferred(base_colorant_type(TransparentRGB)) === TransparentColor # FIXME
-    @test_broken @inferred(base_colorant_type(TransparentRGB)) === TransparentRGB
+    @test @inferred(base_colorant_type(AbstractRGBA{RGB,Float32})) === ColorAlpha{RGB{T},T,4} where T
+    @test @inferred(base_colorant_type(AbstractARGB{RGB{Float64},Float64})) === AlphaColor{RGB{T},T,4} where T
+    @test @inferred(base_colorant_type(TransparentRGB)) === TransparentColor{C,T,4} where C<:AbstractRGB{T} where T
 
-    @test_broken @inferred(base_colorant_type(AbstractGrayA)) === AbstractGrayA
-    @test_broken @inferred(base_colorant_type(AbstractAGray)) === AbstractAGray
-    @test_broken @inferred(base_colorant_type(TransparentGray)) === TransparentGray
+    @test @inferred(base_colorant_type(AbstractGrayA)) === ColorAlpha{C,T,2} where C<:AbstractGray{T} where T
+    @test @inferred(base_colorant_type(AbstractAGray)) === AlphaColor{C,T,2} where C<:AbstractGray{T} where T
+    @test @inferred(base_colorant_type(TransparentGray)) === TransparentColor{C,T,2} where C<:AbstractGray{T} where T
 
-    @test_broken @inferred(base_colorant_type(Color3)) === Color3
-    @test_broken @inferred(base_colorant_type(Transparent3)) === Transparent3
+    @test @inferred(base_colorant_type(Color3)) === Color3
+    @test @inferred(base_colorant_type(Transparent3)) === TransparentColor{C,T,4} where C<:Color{T,3} where T
     @test @inferred(base_colorant_type(Color)) === Color
     @test @inferred(base_colorant_type(TransparentColor)) === TransparentColor
     @test @inferred(base_colorant_type(TransparentColor{RGB})) === TransparentColor # FIXME
@@ -418,10 +414,10 @@ end
     @test @inferred(ccolor(Colorant{N0f8}, RGBX{Float32})) === RGBX{N0f8}
     @test @inferred(ccolor(Colorant{N0f8,3}, BGR{N0f8})) === BGR{N0f8}
 
-    @test @inferred(ccolor(AbstractRGB, HSV{Float32})) === AbstractRGB{Float32} # is not concrete type
-    @test @inferred(ccolor(AbstractRGB{N0f8}, HSV{Float32})) === AbstractRGB{N0f8} # is not concrete type
+    @test_throws TwoColorTypeError ccolor(AbstractRGB, HSV{Float32})
+    @test_throws TwoColorTypeError ccolor(AbstractRGB{N0f8}, HSV{Float32})
     @test @inferred(ccolor(AbstractRGB, RGB24)) === RGB24
-    @test_broken @inferred(ccolor(AbstractRGB{Float32}, RGB24))
+    @test_throws ErrorException ccolor(AbstractRGB{Float32}, RGB24)
 
     @test @inferred(ccolor(RGB, RGB)) == RGB # with symbol `S` instead of `T`
     @test @inferred(ccolor(RGB, HSV)) == RGB # with symbol `S` instead of `T`
@@ -465,18 +461,18 @@ end
     @test @inferred(ccolor(TransparentColor, AHSV{Float32})) === AHSV{Float32}
 
     # Ambiguous storage order, choose AlphaColor or ColorAlpha
-    @test_throws ErrorException ccolor(TransparentColor, HSV{Float32})
-    @test_throws ErrorException ccolor(TransparentColor{RGB}, HSV{Float32})
-    @test_throws ErrorException ccolor(TransparentColor{RGB,Float64}, HSV{Float32})
-    @test_throws ErrorException ccolor(TransparentColor{RGB{Float64},Float64}, HSV{Float32})
-    @test_throws ErrorException ccolor(TransparentColor{RGB{Float64},Float64,4}, HSV{Float32})
+    @test_throws TwoColorTypeError ccolor(TransparentColor, HSV{Float32})
+    @test_throws TwoColorTypeError ccolor(TransparentColor{RGB}, HSV{Float32})
+    @test_throws TwoColorTypeError ccolor(TransparentColor{RGB,Float64}, HSV{Float32})
+    @test_throws TwoColorTypeError ccolor(TransparentColor{RGB{Float64},Float64}, HSV{Float32})
+    @test_throws TwoColorTypeError ccolor(TransparentColor{RGB{Float64},Float64,4}, HSV{Float32})
 
     @test @inferred(ccolor(AlphaColor, RGB)) === ARGB
-    @test_broken @inferred(ccolor(AlphaColor, RGB{N0f8})) === ARGB{N0f8}
+    @test @inferred(ccolor(AlphaColor, RGB{N0f8})) === ARGB{N0f8}
     @test @inferred(ccolor(AlphaColor, RGB24)) === ARGB32
-    @test_broken @inferred(ccolor(AbstractARGB, RGB)) === ARGB
-    @test_broken @inferred(ccolor(AbstractARGB, RGB{N0f8})) === ARGB{N0f8}
-    @test_broken @inferred(ccolor(AbstractARGB, RGB24)) === ARGB32
+    @test @inferred(ccolor(AbstractARGB, RGB)) === ARGB
+    @test @inferred(ccolor(AbstractARGB, RGB{N0f8})) === ARGB{N0f8}
+    @test @inferred(ccolor(AbstractARGB, RGB24)) === ARGB32
 
     for C in filter(T -> T <: AbstractRGB, ColorTypes.parametric3)
         @test @inferred(ccolor(RGB24, C)) === RGB24


### PR DESCRIPTION
This does some maintenance on the type system of ColorTypes. In particular it leverages the huge improvements in Julia's type system and optimizer that allow one to write the code in block form rather than large dispatch chains. This makes it somewhat easier to perform complex logic. It fixes quite a few of our `@test_broken`s, though there are others that should be investigated.

With respect to upstream tests, the most breaking part of this might be the introduction of `TwoColorTypeError`; I can revert that and go back to `ErrorException` if there's a clear consensus against it. But I introduced it to improve printing of error messages for the user.

I have some additional tests I wrote, but they are partly redundant with what we already have. Therefore I'm posting them in a [gist](https://gist.github.com/timholy/21358b924b3a885e9d2a84f3eb3eb15e); folks can tell me whether we want them or not.

If https://github.com/JuliaLang/julia/issues/8322 gets implemented we should make further changes to how the types themselves are declared.

Fixes #153 
Fixes #154