### PR TITLE
Improve promotion rules (Fixes #129)

### DIFF
--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -3,70 +3,119 @@ using Test
 using ColorTypes: ColorTypeResolutionError
 
 @testset "rgb promotions" begin
-    @test        promote( RGB{N0f8}(0.2,0.3,0.4),  RGB(0.3,0.8,0.1)) === ( RGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8),  RGB{Float64}(0.3,0.8,0.1))
-    @test_broken promote( RGB{N0f8}(0.2,0.3,0.4), RGBA(0.3,0.8,0.1)) === (RGBA{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), RGBA{Float64}(0.3,0.8,0.1))
-    @test_broken promote( RGB{N0f8}(0.2,0.3,0.4), ARGB(0.3,0.8,0.1)) === (ARGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), ARGB{Float64}(0.3,0.8,0.1))
-    @test_broken promote(RGBA{N0f8}(0.2,0.3,0.4),  RGB(0.3,0.8,0.1)) === (RGBA{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), RGBA{Float64}(0.3,0.8,0.1))
-    @test_broken promote(RGBA{N0f8}(0.2,0.3,0.4), RGBA(0.3,0.8,0.1)) === (RGBA{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), RGBA{Float64}(0.3,0.8,0.1))
-    @test_broken promote(ARGB{N0f8}(0.2,0.3,0.4),  RGB(0.3,0.8,0.1)) === (ARGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), ARGB{Float64}(0.3,0.8,0.1))
-    @test_broken promote(ARGB{N0f8}(0.2,0.3,0.4), ARGB(0.3,0.8,0.1)) === (ARGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), ARGB{Float64}(0.3,0.8,0.1))
+    @test promote( RGB{N0f8}(0.2,0.3,0.4),  RGB(0.3,0.8,0.1)) === ( RGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8),  RGB{Float64}(0.3,0.8,0.1))
+    @test promote( RGB{N0f8}(0.2,0.3,0.4), RGBA(0.3,0.8,0.1)) === (RGBA{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), RGBA{Float64}(0.3,0.8,0.1))
+    @test promote( RGB{N0f8}(0.2,0.3,0.4), ARGB(0.3,0.8,0.1)) === (ARGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), ARGB{Float64}(0.3,0.8,0.1))
+    @test promote(RGBA{N0f8}(0.2,0.3,0.4),  RGB(0.3,0.8,0.1)) === (RGBA{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), RGBA{Float64}(0.3,0.8,0.1))
+    @test promote(RGBA{N0f8}(0.2,0.3,0.4), RGBA(0.3,0.8,0.1)) === (RGBA{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), RGBA{Float64}(0.3,0.8,0.1))
+    @test promote(ARGB{N0f8}(0.2,0.3,0.4),  RGB(0.3,0.8,0.1)) === (ARGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), ARGB{Float64}(0.3,0.8,0.1))
+    @test promote(ARGB{N0f8}(0.2,0.3,0.4), ARGB(0.3,0.8,0.1)) === (ARGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), ARGB{Float64}(0.3,0.8,0.1))
 
-    @test        promote( RGB24(0.2,0.3,0.4),  RGB(0.3,0.8,0.1)) === ( RGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8),  RGB{Float64}(0.3,0.8,0.1))
-    @test_broken promote( RGB24(0.2,0.3,0.4), RGBA(0.3,0.8,0.1)) === (RGBA{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), RGBA{Float64}(0.3,0.8,0.1))
-    @test_broken promote( RGB24(0.2,0.3,0.4), ARGB(0.3,0.8,0.1)) === (ARGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), ARGB{Float64}(0.3,0.8,0.1))
-    @test_broken promote(ARGB32(0.2,0.3,0.4),  RGB(0.3,0.8,0.1)) === (ARGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), ARGB{Float64}(0.3,0.8,0.1))
-    @test_broken promote(ARGB32(0.2,0.3,0.4), ARGB(0.3,0.8,0.1)) === (ARGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), ARGB{Float64}(0.3,0.8,0.1))
+    @test promote( RGB24(0.2,0.3,0.4),  RGB(0.3,0.8,0.1)) === ( RGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8),  RGB{Float64}(0.3,0.8,0.1))
+    @test promote( RGB24(0.2,0.3,0.4), RGBA(0.3,0.8,0.1)) === (RGBA{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), RGBA{Float64}(0.3,0.8,0.1))
+    @test promote( RGB24(0.2,0.3,0.4), ARGB(0.3,0.8,0.1)) === (ARGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), ARGB{Float64}(0.3,0.8,0.1))
+    @test promote(ARGB32(0.2,0.3,0.4),  RGB(0.3,0.8,0.1)) === (ARGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), ARGB{Float64}(0.3,0.8,0.1))
+    @test promote(ARGB32(0.2,0.3,0.4), ARGB(0.3,0.8,0.1)) === (ARGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), ARGB{Float64}(0.3,0.8,0.1))
 
-    @test        promote( RGB24(0.2,0.3,0.4),  RGB{N0f8}(0.3,0.8,0.1)) === ( RGB{N0f8}(0.2,0.3,0.4),  RGB{N0f8}(0.3,0.8,0.1))
-    @test_broken promote( RGB24(0.2,0.3,0.4), RGBA{N0f8}(0.3,0.8,0.1)) === (RGBA{N0f8}(0.2,0.3,0.4), RGBA{N0f8}(0.3,0.8,0.1))
-    @test_broken promote( RGB24(0.2,0.3,0.4), ARGB{N0f8}(0.3,0.8,0.1)) === (ARGB{N0f8}(0.2,0.3,0.4), ARGB{N0f8}(0.3,0.8,0.1))
-    @test_broken promote(ARGB32(0.2,0.3,0.4),  RGB{N0f8}(0.3,0.8,0.1)) === (ARGB{N0f8}(0.2,0.3,0.4), ARGB{N0f8}(0.3,0.8,0.1))
-    @test_broken promote(ARGB32(0.2,0.3,0.4), ARGB{N0f8}(0.3,0.8,0.1)) === (ARGB{N0f8}(0.2,0.3,0.4), ARGB{N0f8}(0.3,0.8,0.1))
+    @test promote( RGB24(0.2,0.3,0.4),  RGB{N0f8}(0.3,0.8,0.1)) === ( RGB{N0f8}(0.2,0.3,0.4),  RGB{N0f8}(0.3,0.8,0.1))
+    @test promote( RGB24(0.2,0.3,0.4), RGBA{N0f8}(0.3,0.8,0.1)) === (RGBA{N0f8}(0.2,0.3,0.4), RGBA{N0f8}(0.3,0.8,0.1))
+    @test promote( RGB24(0.2,0.3,0.4), ARGB{N0f8}(0.3,0.8,0.1)) === (ARGB{N0f8}(0.2,0.3,0.4), ARGB{N0f8}(0.3,0.8,0.1))
+    @test promote(ARGB32(0.2,0.3,0.4),  RGB{N0f8}(0.3,0.8,0.1)) === (ARGB{N0f8}(0.2,0.3,0.4), ARGB{N0f8}(0.3,0.8,0.1))
+    @test promote(ARGB32(0.2,0.3,0.4), ARGB{N0f8}(0.3,0.8,0.1)) === (ARGB{N0f8}(0.2,0.3,0.4), ARGB{N0f8}(0.3,0.8,0.1))
 
-    @test_broken promote(RGBX{N0f8}(0.2,0.3,0.4),  RGB(0.3,0.8,0.1)) === (RGBX{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), RGBX{Float64}(0.3,0.8,0.1))
-    @test_broken promote(RGBX{N0f8}(0.2,0.3,0.4), RGBA(0.3,0.8,0.1)) === (RGBA{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), RGBA{Float64}(0.3,0.8,0.1))
-    @test_broken promote(RGBX{N0f8}(0.2,0.3,0.4), ARGB(0.3,0.8,0.1)) === (ARGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), ARGB{Float64}(0.3,0.8,0.1))
-    @test_broken promote(XRGB{N0f8}(0.2,0.3,0.4),  RGB(0.3,0.8,0.1)) === (XRGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), XRGB{Float64}(0.3,0.8,0.1))
-    @test_broken promote(XRGB{N0f8}(0.2,0.3,0.4), RGBA(0.3,0.8,0.1)) === (RGBA{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), RGBA{Float64}(0.3,0.8,0.1))
-    @test_broken promote(XRGB{N0f8}(0.2,0.3,0.4), ARGB(0.3,0.8,0.1)) === (ARGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), ARGB{Float64}(0.3,0.8,0.1))
+    @test promote(RGBX{N0f8}(0.2,0.3,0.4),  RGB(0.3,0.8,0.1)) === (RGBX{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), RGBX{Float64}(0.3,0.8,0.1))
+    @test promote(RGBX{N0f8}(0.2,0.3,0.4), RGBA(0.3,0.8,0.1)) === (RGBA{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), RGBA{Float64}(0.3,0.8,0.1))
+    @test promote(RGBX{N0f8}(0.2,0.3,0.4), ARGB(0.3,0.8,0.1)) === (ARGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), ARGB{Float64}(0.3,0.8,0.1))
+    @test promote(XRGB{N0f8}(0.2,0.3,0.4),  RGB(0.3,0.8,0.1)) === (XRGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), XRGB{Float64}(0.3,0.8,0.1))
+    @test promote(XRGB{N0f8}(0.2,0.3,0.4), RGBA(0.3,0.8,0.1)) === (RGBA{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), RGBA{Float64}(0.3,0.8,0.1))
+    @test promote(XRGB{N0f8}(0.2,0.3,0.4), ARGB(0.3,0.8,0.1)) === (ARGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), ARGB{Float64}(0.3,0.8,0.1))
 
-    @test_broken promote(RGBX(0.2,0.3,0.4),  RGB{N0f8}(0.3,0.8,0.1)) === (RGBX{Float64}(0.2,0.3,0.4), RGBX{Float64}(0.3N0f8,0.8N0f8,0.1N0f8))
-    @test_broken promote(RGBX(0.2,0.3,0.4), RGBA{N0f8}(0.3,0.8,0.1)) === (RGBA{Float64}(0.2,0.3,0.4), RGBA{Float64}(0.3N0f8,0.8N0f8,0.1N0f8))
-    @test_broken promote(RGBX(0.2,0.3,0.4), ARGB{N0f8}(0.3,0.8,0.1)) === (ARGB{Float64}(0.2,0.3,0.4), ARGB{Float64}(0.3N0f8,0.8N0f8,0.1N0f8))
-    @test_broken promote(XRGB(0.2,0.3,0.4),  RGB{N0f8}(0.3,0.8,0.1)) === (XRGB{Float64}(0.2,0.3,0.4), XRGB{Float64}(0.3N0f8,0.8N0f8,0.1N0f8))
-    @test_broken promote(XRGB(0.2,0.3,0.4), RGBA{N0f8}(0.3,0.8,0.1)) === (RGBA{Float64}(0.2,0.3,0.4), RGBA{Float64}(0.3N0f8,0.8N0f8,0.1N0f8))
-    @test_broken promote(XRGB(0.2,0.3,0.4), ARGB{N0f8}(0.3,0.8,0.1)) === (ARGB{Float64}(0.2,0.3,0.4), ARGB{Float64}(0.3N0f8,0.8N0f8,0.1N0f8))
+    @test promote(RGBX(0.2,0.3,0.4),  RGB{N0f8}(0.3,0.8,0.1)) === (RGBX{Float64}(0.2,0.3,0.4), RGBX{Float64}(0.3N0f8,0.8N0f8,0.1N0f8))
+    @test promote(RGBX(0.2,0.3,0.4), RGBA{N0f8}(0.3,0.8,0.1)) === (RGBA{Float64}(0.2,0.3,0.4), RGBA{Float64}(0.3N0f8,0.8N0f8,0.1N0f8))
+    @test promote(RGBX(0.2,0.3,0.4), ARGB{N0f8}(0.3,0.8,0.1)) === (ARGB{Float64}(0.2,0.3,0.4), ARGB{Float64}(0.3N0f8,0.8N0f8,0.1N0f8))
+    @test promote(XRGB(0.2,0.3,0.4),  RGB{N0f8}(0.3,0.8,0.1)) === (XRGB{Float64}(0.2,0.3,0.4), XRGB{Float64}(0.3N0f8,0.8N0f8,0.1N0f8))
+    @test promote(XRGB(0.2,0.3,0.4), RGBA{N0f8}(0.3,0.8,0.1)) === (RGBA{Float64}(0.2,0.3,0.4), RGBA{Float64}(0.3N0f8,0.8N0f8,0.1N0f8))
+    @test promote(XRGB(0.2,0.3,0.4), ARGB{N0f8}(0.3,0.8,0.1)) === (ARGB{Float64}(0.2,0.3,0.4), ARGB{Float64}(0.3N0f8,0.8N0f8,0.1N0f8))
+
+    @test promote_type(RGB, RGB) === RGB
+    @test promote_type(RGB, RGB{Float16}) === RGB
+    @test promote_type(RGB, RGB24) === RGB
+
+    @test promote_type(RGB, RGBA) === RGBA
+    @test promote_type(ARGB, RGB) === ARGB
+    @test promote_type(RGB, RGBA{Float16}) === RGBA
+    @test promote_type(ARGB, RGB{Float16}) === ARGB
+    @test promote_type(RGB, ARGB32) === ARGB
+
+    @test promote_type(RGB, BGR) === RGB
+    @test promote_type(RGB, BGR{Float16}) === RGB
+    @test promote_type(BGR, RGB{Float16}) === RGB
+    @test promote_type(BGR, RGB24) === RGB
+
+    @test promote_type(RGB, RGBX) === RGBX
+    @test promote_type(XRGB, RGB) === XRGB
+    @test promote_type(RGB, RGBX{Float16}) === RGBX
+    @test promote_type(XRGB, RGB{Float16}) === XRGB
+
+    @test promote_type(AbstractRGB, RGB{Float16}) === RGB
+    @test promote_type(RGB, AbstractRGB{Float16}) === RGB
+    @test promote_type(AbstractRGB{Float16}, RGB{Float16}) === RGB{Float16}
+    @test promote_type(AbstractRGB{Float16}, RGB24) === RGB{Float32}
 end
 
 @testset "hsv promotions" begin
-    @test_broken promote( HSV{Float32}(100,0.3,0.4),  HSV(200,0.8,0.1)) === ( HSV{Float64}(100,0.3f0,0.4f0),  HSV{Float64}(200,0.8,0.1))
-    @test_broken promote( HSV{Float32}(100,0.3,0.4), HSVA(200,0.8,0.1)) === (HSVA{Float64}(100,0.3f0,0.4f0), HSVA{Float64}(200,0.8,0.1))
-    @test_broken promote( HSV{Float32}(100,0.3,0.4), AHSV(200,0.8,0.1)) === (AHSV{Float64}(100,0.3f0,0.4f0), AHSV{Float64}(200,0.8,0.1))
-    @test_broken promote(HSVA{Float32}(100,0.3,0.4),  HSV(200,0.8,0.1)) === (HSVA{Float64}(100,0.3f0,0.4f0), HSVA{Float64}(200,0.8,0.1))
-    @test_broken promote(HSVA{Float32}(100,0.3,0.4), HSVA(200,0.8,0.1)) === (HSVA{Float64}(100,0.3f0,0.4f0), HSVA{Float64}(200,0.8,0.1))
-    @test_broken promote(AHSV{Float32}(100,0.3,0.4),  HSV(200,0.8,0.1)) === (AHSV{Float64}(100,0.3f0,0.4f0), AHSV{Float64}(200,0.8,0.1))
-    @test_broken promote(AHSV{Float32}(100,0.3,0.4), AHSV(200,0.8,0.1)) === (AHSV{Float64}(100,0.3f0,0.4f0), AHSV{Float64}(200,0.8,0.1))
+    @test promote( HSV{Float32}(100,0.3,0.4),  HSV(200,0.8,0.1)) === ( HSV{Float64}(100,0.3f0,0.4f0),  HSV{Float64}(200,0.8,0.1))
+    @test promote( HSV{Float32}(100,0.3,0.4), HSVA(200,0.8,0.1)) === (HSVA{Float64}(100,0.3f0,0.4f0), HSVA{Float64}(200,0.8,0.1))
+    @test promote( HSV{Float32}(100,0.3,0.4), AHSV(200,0.8,0.1)) === (AHSV{Float64}(100,0.3f0,0.4f0), AHSV{Float64}(200,0.8,0.1))
+    @test promote(HSVA{Float32}(100,0.3,0.4),  HSV(200,0.8,0.1)) === (HSVA{Float64}(100,0.3f0,0.4f0), HSVA{Float64}(200,0.8,0.1))
+    @test promote(HSVA{Float32}(100,0.3,0.4), HSVA(200,0.8,0.1)) === (HSVA{Float64}(100,0.3f0,0.4f0), HSVA{Float64}(200,0.8,0.1))
+    @test promote(AHSV{Float32}(100,0.3,0.4),  HSV(200,0.8,0.1)) === (AHSV{Float64}(100,0.3f0,0.4f0), AHSV{Float64}(200,0.8,0.1))
+    @test promote(AHSV{Float32}(100,0.3,0.4), AHSV(200,0.8,0.1)) === (AHSV{Float64}(100,0.3f0,0.4f0), AHSV{Float64}(200,0.8,0.1))
+
+    @test promote_type(HSV, HSV) === HSV
+    @test promote_type(HSV, HSV{Float16}) === HSV
+
+    @test promote_type(HSV, HSVA) === HSVA
+    @test promote_type(AHSV, HSV) === AHSV
+    @test promote_type(HSV, HSVA{Float16}) === HSVA
+    @test promote_type(AHSV, HSV{Float16}) === AHSV
 end
 
 @testset "gray promotions" begin
-    @test        promote( Gray{N0f8}(0.2),  Gray(0.3)) === ( Gray{Float64}(0.2N0f8),  Gray{Float64}(0.3))
-    @test_broken promote( Gray{N0f8}(0.2), GrayA(0.3)) === (GrayA{Float64}(0.2N0f8), GrayA{Float64}(0.3))
-    @test_broken promote( Gray{N0f8}(0.2), AGray(0.3)) === (AGray{Float64}(0.2N0f8), AGray{Float64}(0.3))
-    @test_broken promote(GrayA{N0f8}(0.2),  Gray(0.3)) === (GrayA{Float64}(0.2N0f8), GrayA{Float64}(0.3))
-    @test_broken promote(GrayA{N0f8}(0.2), GrayA(0.3)) === (GrayA{Float64}(0.2N0f8), GrayA{Float64}(0.3))
-    @test_broken promote(AGray{N0f8}(0.2),  Gray(0.3)) === (AGray{Float64}(0.2N0f8), AGray{Float64}(0.3))
-    @test_broken promote(AGray{N0f8}(0.2), AGray(0.3)) === (AGray{Float64}(0.2N0f8), AGray{Float64}(0.3))
+    @test promote( Gray{N0f8}(0.2),  Gray(0.3)) === ( Gray{Float64}(0.2N0f8),  Gray{Float64}(0.3))
+    @test promote( Gray{N0f8}(0.2), GrayA(0.3)) === (GrayA{Float64}(0.2N0f8), GrayA{Float64}(0.3))
+    @test promote( Gray{N0f8}(0.2), AGray(0.3)) === (AGray{Float64}(0.2N0f8), AGray{Float64}(0.3))
+    @test promote(GrayA{N0f8}(0.2),  Gray(0.3)) === (GrayA{Float64}(0.2N0f8), GrayA{Float64}(0.3))
+    @test promote(GrayA{N0f8}(0.2), GrayA(0.3)) === (GrayA{Float64}(0.2N0f8), GrayA{Float64}(0.3))
+    @test promote(AGray{N0f8}(0.2),  Gray(0.3)) === (AGray{Float64}(0.2N0f8), AGray{Float64}(0.3))
+    @test promote(AGray{N0f8}(0.2), AGray(0.3)) === (AGray{Float64}(0.2N0f8), AGray{Float64}(0.3))
 
-    @test        promote( Gray24(0.2),  Gray(0.3)) === ( Gray{Float64}(0.2N0f8),  Gray{Float64}(0.3))
-    @test_broken promote( Gray24(0.2), GrayA(0.3)) === (GrayA{Float64}(0.2N0f8), GrayA{Float64}(0.3))
-    @test_broken promote( Gray24(0.2), AGray(0.3)) === (AGray{Float64}(0.2N0f8), AGray{Float64}(0.3))
-    @test_broken promote(AGray32(0.2),  Gray(0.3)) === (AGray{Float64}(0.2N0f8), AGray{Float64}(0.3))
-    @test_broken promote(AGray32(0.2), AGray(0.3)) === (AGray{Float64}(0.2N0f8), AGray{Float64}(0.3))
-    @test        promote( Gray24(0.2),  Gray{N0f8}(0.3)) === ( Gray{N0f8}(0.2),  Gray{N0f8}(0.3))
-    @test_broken promote( Gray24(0.2), GrayA{N0f8}(0.3)) === (GrayA{N0f8}(0.2), GrayA{N0f8}(0.3))
-    @test_broken promote( Gray24(0.2), AGray{N0f8}(0.3)) === (AGray{N0f8}(0.2), AGray{N0f8}(0.3))
-    @test_broken promote(AGray32(0.2),  Gray{N0f8}(0.3)) === (AGray{N0f8}(0.2), AGray{N0f8}(0.3))
-    @test_broken promote(AGray32(0.2), AGray{N0f8}(0.3)) === (AGray{N0f8}(0.2), AGray{N0f8}(0.3))
+    @test promote( Gray24(0.2),  Gray(0.3)) === ( Gray{Float64}(0.2N0f8),  Gray{Float64}(0.3))
+    @test promote( Gray24(0.2), GrayA(0.3)) === (GrayA{Float64}(0.2N0f8), GrayA{Float64}(0.3))
+    @test promote( Gray24(0.2), AGray(0.3)) === (AGray{Float64}(0.2N0f8), AGray{Float64}(0.3))
+    @test promote(AGray32(0.2),  Gray(0.3)) === (AGray{Float64}(0.2N0f8), AGray{Float64}(0.3))
+    @test promote(AGray32(0.2), AGray(0.3)) === (AGray{Float64}(0.2N0f8), AGray{Float64}(0.3))
+    @test promote( Gray24(0.2),  Gray{N0f8}(0.3)) === ( Gray{N0f8}(0.2),  Gray{N0f8}(0.3))
+    @test promote( Gray24(0.2), GrayA{N0f8}(0.3)) === (GrayA{N0f8}(0.2), GrayA{N0f8}(0.3))
+    @test promote( Gray24(0.2), AGray{N0f8}(0.3)) === (AGray{N0f8}(0.2), AGray{N0f8}(0.3))
+    @test promote(AGray32(0.2),  Gray{N0f8}(0.3)) === (AGray{N0f8}(0.2), AGray{N0f8}(0.3))
+    @test promote(AGray32(0.2), AGray{N0f8}(0.3)) === (AGray{N0f8}(0.2), AGray{N0f8}(0.3))
+
+    @test promote_type(Gray, Gray) === Gray
+    @test promote_type(Gray, Gray{Float16}) === Gray
+    @test promote_type(Gray, Gray24) === Gray
+
+    @test promote_type(Gray, GrayA) === GrayA
+    @test promote_type(AGray, Gray) === AGray
+    @test promote_type(Gray, GrayA{Float16}) === GrayA
+    @test promote_type(AGray, Gray{Float16}) === AGray
+
+    @test promote_type(AGray, Gray{Bool}) === AGray
+
+    @test promote_type(AbstractGray, Gray{Float16}) === Gray
+    @test promote_type(Gray, AbstractGray{Float16}) === Gray
+    @test promote_type(AbstractGray{Float16}, Gray{Float16}) === Gray{Float16}
+    @test promote_type(AbstractGray{Float16}, Gray24) === Gray{Float32}
 end
 
 @testset "rgb and gray promotions" begin
@@ -100,12 +149,12 @@ end
     @test promote(ARGB(0.2,0.3,0.4), GrayA{N0f8}(0.8)) === (ARGB{Float64}(0.2,0.3,0.4,1), ARGB{Float64}(0.8N0f8,0.8N0f8,0.8N0f8,1))
     @test promote(ARGB(0.2,0.3,0.4), AGray{N0f8}(0.8)) === (ARGB{Float64}(0.2,0.3,0.4,1), ARGB{Float64}(0.8N0f8,0.8N0f8,0.8N0f8,1))
 
-    @test_broken promote( RGB24(0.2,0.3,0.4),  Gray(0.8)) === ( RGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8),  RGB{Float64}(0.8,0.8,0.8,0.1))
-    @test_broken promote( RGB24(0.2,0.3,0.4), GrayA(0.8)) === (RGBA{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), RGBA{Float64}(0.8,0.8,0.8,0.1))
-    @test_broken promote( RGB24(0.2,0.3,0.4), AGray(0.8)) === (ARGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), ARGB{Float64}(0.8,0.8,0.8,0.1))
-    @test_broken promote(ARGB32(0.2,0.3,0.4),  Gray(0.8)) === (ARGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), ARGB{Float64}(0.8,0.8,0.8,0.1))
-    @test_broken promote(ARGB32(0.2,0.3,0.4), GrayA(0.8)) === (ARGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), ARGB{Float64}(0.8,0.8,0.8,0.1))
-    @test_broken promote(ARGB32(0.2,0.3,0.4), AGray(0.8)) === (ARGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), ARGB{Float64}(0.8,0.8,0.8,0.1))
+    @test promote( RGB24(0.2,0.3,0.4),  Gray(0.8)) === (RGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), RGB{Float64}(0.8,0.8,0.8))
+    @test promote( RGB24(0.2,0.3,0.4), GrayA(0.8)) === (RGBA{Float64}(0.2N0f8,0.3N0f8,0.4N0f8,1), RGBA{Float64}(0.8,0.8,0.8,1))
+    @test promote( RGB24(0.2,0.3,0.4), AGray(0.8)) === (ARGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8,1), ARGB{Float64}(0.8,0.8,0.8,1))
+    @test promote(ARGB32(0.2,0.3,0.4),  Gray(0.8)) === (ARGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8,1), ARGB{Float64}(0.8,0.8,0.8,1))
+    @test promote(ARGB32(0.2,0.3,0.4), GrayA(0.8)) === (ARGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8,1), ARGB{Float64}(0.8,0.8,0.8,1))
+    @test promote(ARGB32(0.2,0.3,0.4), AGray(0.8)) === (ARGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8,1), ARGB{Float64}(0.8,0.8,0.8,1))
 
     @test promote( RGB(0.2,0.3,0.4),  Gray24(0.8)) === (RGB{Float64}(0.2,0.3,0.4), RGB{Float64}(0.8N0f8,0.8N0f8,0.8N0f8))
     @test promote( RGB(0.2,0.3,0.4), AGray32(0.8)) === (ARGB{Float64}(0.2,0.3,0.4,1), ARGB{Float64}(0.8N0f8,0.8N0f8,0.8N0f8,1))
@@ -114,14 +163,174 @@ end
     @test promote(ARGB(0.2,0.3,0.4),  Gray24(0.8)) === (ARGB{Float64}(0.2,0.3,0.4,1), ARGB{Float64}(0.8N0f8,0.8N0f8,0.8N0f8,1))
     @test promote(ARGB(0.2,0.3,0.4), AGray32(0.8)) === (ARGB{Float64}(0.2,0.3,0.4,1), ARGB{Float64}(0.8N0f8,0.8N0f8,0.8N0f8,1))
 
-    @test_broken promote( RGB24(0.2,0.3,0.4),  Gray24(0.8)) === (RGB24(0.2,0.3,0.4), RGB24(0.8,0.8,0.8))
-    @test_broken promote( RGB24(0.2,0.3,0.4), AGray32(0.8)) === (ARGB32(0.2,0.3,0.4,1), ARGB32(0.8,0.8,0.8,1))
-    @test_broken promote(ARGB32(0.2,0.3,0.4),  Gray24(0.8)) === (ARGB32(0.2,0.3,0.4,1), ARGB32(0.8,0.8,0.8,1))
-    @test_broken promote(ARGB32(0.2,0.3,0.4), AGray32(0.8)) === (ARGB32(0.2,0.3,0.4,1), ARGB32(0.8,0.8,0.8,1))
+    @test promote( RGB24(0.2,0.3,0.4),  Gray24(0.8)) === (RGB24(0.2,0.3,0.4), RGB24(0.8,0.8,0.8))
+    @test promote( RGB24(0.2,0.3,0.4), AGray32(0.8)) === (ARGB32(0.2,0.3,0.4,1), ARGB32(0.8,0.8,0.8,1))
+    @test promote(ARGB32(0.2,0.3,0.4),  Gray24(0.8)) === (ARGB32(0.2,0.3,0.4,1), ARGB32(0.8,0.8,0.8,1))
+    @test promote(ARGB32(0.2,0.3,0.4), AGray32(0.8)) === (ARGB32(0.2,0.3,0.4,1), ARGB32(0.8,0.8,0.8,1))
 
     @test promote(RGB(0.2,0.3,0.4), Gray{Bool}(1)) === (RGB{Float64}(0.2,0.3,0.4), RGB{Float64}(1,1,1))
     @test promote(RGB{N0f8}(0.2,0.3,0.4), Gray{Bool}(1)) === (RGB{N0f8}(0.2,0.3,0.4), RGB{N0f8}(1,1,1))
+
+    @test promote_type(RGB, Gray) === RGB
+    @test promote_type(RGB, Gray{Float16}) === RGB
+    @test promote_type(Gray, RGB{Float16}) === RGB
+
+    @test promote_type(RGB, GrayA) === RGBA
+    @test promote_type(AGray, RGB) === ARGB
+    @test promote_type(RGB, GrayA{Float16}) === RGBA
+    @test promote_type(AGray, RGB{Float16}) === ARGB
+
+    @test promote_type(Gray, RGBA) === RGBA
+    @test promote_type(ARGB, Gray) === ARGB
+    @test promote_type(Gray, RGBA{Float16}) === RGBA
+    @test promote_type(ARGB, Gray{Float16}) === ARGB
+
+    @test promote_type(RGB, Gray{Bool}) === RGB
+    @test promote_type(ARGB, Gray{Bool}) === ARGB
+    @test promote_type(RGBA, Gray{Bool}) === RGBA
+
+    @test promote_type(RGB, Gray24) === RGB
+    @test promote_type(RGBA, Gray24) === RGBA
+    @test promote_type(ARGB, AGray32) === ARGB
+    @test promote_type(RGB24, Gray) === RGB
+    @test promote_type(RGB24, GrayA) === RGBA
+    @test promote_type(ARGB32, Gray) === ARGB
+    @test promote_type(ARGB32, GrayA) === ARGB
+
+    @test promote_type(AbstractRGB, Gray{Float16}) === RGB
+    @test promote_type(RGB, AbstractGray{Float16}) === RGB
+    @test promote_type(AbstractRGB{Float16}, Gray{Float16}) === RGB{Float16}
+    @test promote_type(AbstractRGB{Float16}, Gray24) === RGB{Float32}
+
+    @test promote_type(AbstractGray, RGB{Float16}) === RGB
+    @test promote_type(Gray, AbstractRGB{Float16}) === RGB
+    @test promote_type(AbstractGray{Float16}, RGB{Float16}) === RGB{Float16}
+    @test promote_type(AbstractGray{Float16}, RGB24) === RGB{Float32}
+
+    @test promote_type(AbstractRGB, AGray{Float16}) === ARGB
+    @test promote_type(RGB, AbstractAGray{Gray{Float16},Float16}) === ARGB
+    @test promote_type(AbstractRGB{Float16}, AGray{Float16}) === ARGB{Float16}
+    @test promote_type(AbstractRGB{Float16}, AGray32) === ARGB{Float32}
+
+    @test promote_type(AbstractGray, ARGB{Float16}) === ARGB
+    @test promote_type(Gray, AbstractARGB{RGB{Float16},Float16}) === ARGB
+    @test promote_type(AbstractGray{Float16}, ARGB{Float16}) === ARGB{Float16}
+    @test promote_type(AbstractGray{Float16}, ARGB32) === ARGB{Float32}
+
+    @test_broken promote_type(AbstractARGB, AGray{Float16}) === ARGB
+    @test promote_type(ARGB, AbstractAGray{Gray{Float16},Float16}) === ARGB
+    @test_broken promote_type(AbstractARGB{RGB{Float16},Float16}, AGray{Float16}) === ARGB{Float16}
+    @test_broken promote_type(AbstractARGB{RGB{Float16},Float16}, AGray32) === ARGB{Float32}
 end
+
+@testset "hsv and gray promotions" begin
+    @test promote_type( HSV{Float16},  Gray{N0f8}) === HSV{Float32}
+    @test promote_type( HSV{Float16}, GrayA{N0f8}) === HSVA{Float32}
+    @test promote_type( HSV{Float16}, AGray{N0f8}) === AHSV{Float32}
+    @test promote_type(HSVA{Float16},  Gray{N0f8}) === HSVA{Float32}
+    @test promote_type(HSVA{Float16}, GrayA{N0f8}) === HSVA{Float32}
+    @test promote_type(HSVA{Float16}, AGray{N0f8}) === HSVA{Float32}
+    @test promote_type(AHSV{Float16},  Gray{N0f8}) === AHSV{Float32}
+    @test promote_type(AHSV{Float16}, GrayA{N0f8}) === AHSV{Float32}
+    @test promote_type(AHSV{Float16}, AGray{N0f8}) === AHSV{Float32}
+
+    @test promote_type( HSV{Float16},  Gray24) === HSV{Float32}
+    @test promote_type( HSV{Float16}, AGray32) === AHSV{Float32}
+    @test promote_type(HSVA{Float16},  Gray24) === HSVA{Float32}
+    @test promote_type(HSVA{Float16}, AGray32) === HSVA{Float32}
+    @test promote_type(AHSV{Float16},  Gray24) === AHSV{Float32}
+    @test promote_type(AHSV{Float16}, AGray32) === AHSV{Float32}
+
+    @test promote_type(HSV{Float64}, Gray{Bool}) === HSV{Float64}
+    @test promote_type(HSV{Float32}, Gray{Bool}) === HSV{Float32}
+
+    @test promote_type(HSV, Gray) === HSV
+    @test promote_type(HSV, Gray{Float16}) === HSV
+    @test promote_type(Gray, HSV{Float16}) === HSV
+
+    @test promote_type(HSV, GrayA) === HSVA
+    @test promote_type(AGray, HSV) === AHSV
+    @test promote_type(HSV, GrayA{Float16}) === HSVA
+    @test promote_type(AGray, HSV{Float16}) === AHSV
+
+    @test promote_type(Gray, HSVA) === HSVA
+    @test promote_type(AHSV, Gray) === AHSV
+    @test promote_type(Gray, HSVA{Float16}) === HSVA
+    @test promote_type(AHSV, Gray{Float16}) === AHSV
+
+    @test promote_type(GrayA, HSVA) === HSVA
+    @test promote_type(AHSV, AGray) === AHSV
+    @test promote_type(AGray, HSVA) === HSVA
+    @test promote_type(AHSV, GrayA) === AHSV
+
+    @test promote_type( HSV,  Gray24) === HSV
+    @test promote_type( HSV, AGray32) === AHSV
+    @test promote_type(HSVA,  Gray24) === HSVA
+    @test promote_type(HSVA, AGray32) === HSVA
+    @test promote_type(AHSV,  Gray24) === AHSV
+    @test promote_type(AHSV, AGray32) === AHSV
+end
+
+# promotions between different color spaces
+@testset "rgb and hsv promotions" begin
+    # the current implementation is like `typejoin`.
+    @test promote_type( RGB{Float64},  HSV{Float64}) == Color3{Float64}
+    @test promote_type( RGB{Float64}, HSVA{Float64}) == ColorAlpha{C,Float64,4} where {C<:Color3{Float64}}
+    @test promote_type( RGB{Float64}, AHSV{Float64}) == AlphaColor{C,Float64,4} where {C<:Color3{Float64}}
+    @test promote_type(RGBA{Float64},  HSV{Float64}) == ColorAlpha{C,Float64,4} where {C<:Color3{Float64}}
+    @test promote_type(RGBA{Float64}, HSVA{Float64}) == ColorAlpha{C,Float64,4} where {C<:Color3{Float64}}
+    @test promote_type(RGBA{Float64}, AHSV{Float64}) == TransparentColor{C,Float64,4} where {C<:Color3{Float64}}
+    @test promote_type(ARGB{Float64},  HSV{Float64}) == AlphaColor{C,Float64,4} where {C<:Color3{Float64}}
+    @test promote_type(ARGB{Float64}, HSVA{Float64}) == TransparentColor{C,Float64,4} where {C<:Color3{Float64}}
+    @test promote_type(ARGB{Float64}, AHSV{Float64}) == AlphaColor{C,Float64,4} where {C<:Color3{Float64}}
+
+    @test promote_type( RGB{N0f8},  HSV{Float16}) == Color3{Float32}
+    @test promote_type( RGB{N0f8}, HSVA{Float16}) == ColorAlpha{C,Float32,4} where {C<:Color3{Float32}}
+    @test promote_type( RGB{N0f8}, AHSV{Float16}) == AlphaColor{C,Float32,4} where {C<:Color3{Float32}}
+    @test promote_type(RGBA{N0f8},  HSV{Float16}) == ColorAlpha{C,Float32,4} where {C<:Color3{Float32}}
+    @test promote_type(RGBA{N0f8}, HSVA{Float16}) == ColorAlpha{C,Float32,4} where {C<:Color3{Float32}}
+    @test promote_type(RGBA{N0f8}, AHSV{Float16}) == TransparentColor{C,Float32,4} where {C<:Color3{Float32}}
+    @test promote_type(ARGB{N0f8},  HSV{Float16}) == AlphaColor{C,Float32,4} where {C<:Color3{Float32}}
+    @test promote_type(ARGB{N0f8}, HSVA{Float16}) == TransparentColor{C,Float32,4} where {C<:Color3{Float32}}
+    @test promote_type(ARGB{N0f8}, AHSV{Float16}) == AlphaColor{C,Float32,4} where {C<:Color3{Float32}}
+
+    @test promote_type( RGB24,  HSV{Float16}) == Color3{Float32}
+    @test promote_type( RGB24, HSVA{Float16}) == ColorAlpha{C,Float32,4} where {C<:Color3{Float32}}
+    @test promote_type( RGB24, AHSV{Float16}) == AlphaColor{C,Float32,4} where {C<:Color3{Float32}}
+    @test promote_type(ARGB32,  HSV{Float16}) == AlphaColor{C,Float32,4} where {C<:Color3{Float32}}
+    @test promote_type(ARGB32, HSVA{Float16}) == TransparentColor{C,Float32,4} where {C<:Color3{Float32}}
+    @test promote_type(ARGB32, AHSV{Float16}) == AlphaColor{C,Float32,4} where {C<:Color3{Float32}}
+
+    @test promote_type(RGB, HSV) == Color3
+    @test promote_type(RGB, HSV{Float16}) == Color3
+    @test promote_type(HSV, RGB{Float16}) == Color3
+
+    @test promote_type(RGB, HSVA) == ColorAlpha{C,T,4} where {T, C<:Color3{T}}
+    @test promote_type(AHSV, RGB) == AlphaColor{C,T,4} where {T, C<:Color3{T}}
+    @test promote_type(RGB, HSVA{Float16}) == ColorAlpha{C,T,4} where {T, C<:Color3{T}}
+    @test promote_type(AHSV, RGB{Float16}) == AlphaColor{C,T,4} where {T, C<:Color3{T}}
+
+    @test promote_type(HSV, RGBA) == ColorAlpha{C,T,4} where {T, C<:Color3{T}}
+    @test promote_type(ARGB, HSV) == AlphaColor{C,T,4} where {T, C<:Color3{T}}
+    @test promote_type(HSV, RGBA{Float16}) == ColorAlpha{C,T,4} where {T, C<:Color3{T}}
+    @test promote_type(ARGB, HSV{Float16}) == AlphaColor{C,T,4} where {T, C<:Color3{T}}
+
+    @test promote_type(HSVA, RGBA) == ColorAlpha{C,T,4} where {T, C<:Color3{T}}
+    @test promote_type(ARGB, AHSV) == AlphaColor{C,T,4} where {T, C<:Color3{T}}
+    @test promote_type(HSVA, RGBA{Float16}) == ColorAlpha{C,T,4} where {T, C<:Color3{T}}
+    @test promote_type(ARGB, AHSV{Float16}) == AlphaColor{C,T,4} where {T, C<:Color3{T}}
+
+    @test promote_type(AHSV, RGBA) == TransparentColor{C,T,4} where {T, C<:Color3{T}} # != Transparent3
+    @test promote_type(ARGB, HSVA) == TransparentColor{C,T,4} where {T, C<:Color3{T}} # != Transparent3
+    @test promote_type(AHSV, RGBA{Float16}) == TransparentColor{C,T,4} where {T, C<:Color3{T}} # != Transparent3
+    @test promote_type(ARGB, HSVA{Float16}) == TransparentColor{C,T,4} where {T, C<:Color3{T}} # != Transparent3
+
+    @test promote_type(RGB24, HSV) == Color3
+    @test promote_type(RGB24, HSVA{Float16}) == ColorAlpha{C,Float32,4} where C<:Color3{Float32}
+    @test promote_type(ARGB32, HSV) == AlphaColor{C,T,4} where {T, C<:Color3{T}}
+    @test promote_type(ARGB32, HSVA{Float16}) == TransparentColor{C,Float32,4} where C<:Color3{Float32}
+end
+
 
 @testset "rgb conversions with abstract types" begin
     c = RGB(1, 0.6, 0)


### PR DESCRIPTION
This fixes #129 and https://github.com/JuliaGraphics/Colors.jl/issues/273.
This PR just focus on fixing broken tests quickly, because I want to release the next version of Colors.jl quickly. So, there is probably a lot of room for improvement.

~This implementation returns `HSV{Float16}` for `promote_type(HSV, HSV{Float16})`. This behavior might be controversial.
This implementation causes `StackOverflow` for unresolved pairs.~
```julia
julia> promote_type(HSV, RGB)
ERROR: StackOverflowError:
```
~I can prevent the `StackOverflow`, but we will end up with an error somewhere else.~
See below.