### PR TITLE
[Alternative] Improve promotion rules (Fixes #129)

### DIFF
--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -1,12 +1,71 @@
-Base.promote_rule(::Type{T1}, ::Type{T2}) where {T1<:AbstractGray,T2<:AbstractGray} = Gray{promote_type(eltype(T1), eltype(T2))}
-Base.promote_rule(::Type{T1}, ::Type{T2}) where {T1<:AbstractRGB,T2<:AbstractRGB} = RGB{promote_type(eltype(T1), eltype(T2))}
+# Get the promoted element type
+# Note that `promote_eltype` defined in "types.jl" means promote "arguments".
+function _promote_et(::Type{C1}, ::Type{C2}) where {C1<:Colorant, C2<:Colorant}
+    T1 = isconcretetype(eltype(C1)) ? eltype(C1) : eltypes_supported(C1)
+    T2 = isconcretetype(eltype(C2)) ? eltype(C2) : eltypes_supported(C2)
+    promote_type(T1, T2)
+end
+# Get the promoted base "color" type
+_promote_color(::Type{C},  ::Type{C})  where {C<:Color} = C
+_promote_color(::Type{C},  ::Type{C})  where {N, C<:ColorN{N}} = C
+_promote_color(::Type{C1}, ::Type{C2}) where {C1<:Color, C2<:Color} = Color
+_promote_color(::Type{C1}, ::Type{C2}) where {N1, C1<:ColorN{N1}, N2, C2<:ColorN{N2}} = ColorN{max(N1, N2)}
+_promote_color(::Type{C1}, ::Type{C2}) where {C1<:AbstractGray, C2<:Color} = _promote_color(C2, C2) # C2 may be AbstractRGB
+_promote_color(::Type{C1}, ::Type{C2}) where {C1<:Color, C2<:AbstractGray} = _promote_color(C1, C1) # C1 may be AbstractRGB
+_promote_color(::Type{C1}, ::Type{C2}) where {C1<:AbstractGray, N2, C2<:ColorN{N2}} = _promote_color(C2, C2)
+_promote_color(::Type{C1}, ::Type{C2}) where {N1, C1<:ColorN{N1}, C2<:AbstractGray} = _promote_color(C1, C1)
+_promote_color(::Type{C1}, ::Type{C2}) where {C1<:AbstractGray, C2<:AbstractGray} = Gray
+function _promote_color(::Type{C1}, ::Type{C2}) where {C1<:AbstractRGB, C2<:AbstractRGB}
+    (C1 === XRGB || C2 === XRGB) && return XRGB
+    (C1 === RGBX || C2 === RGBX) && return RGBX
+    RGB
+end
 
-Base.promote_rule(::Type{C3}, ::Type{Cgray}) where {C3<:Color3,Cgray<:AbstractGray} = base_colorant_type(C3){promote_type(eltype(C3), eltype(Cgray))}
-Base.promote_rule(::Type{C3}, ::Type{Cagray}) where {C3<:Color3,Cagray<:AbstractAGray} = alphacolor(base_colorant_type(C3)){promote_type(eltype(C3), eltype(Cagray))}
-Base.promote_rule(::Type{C3}, ::Type{Cgraya}) where {C3<:Color3,Cgraya<:AbstractGrayA} = coloralpha(base_colorant_type(C3)){promote_type(eltype(C3), eltype(Cgraya))}
+# Get the promoted transparent type
+_promote_alpha(::Type{C1}, ::Type{C2}) where {C1<:Colorant, C2<:Colorant} = AlphaColor
+_promote_alpha(::Type{C1}, ::Type{C2}) where {C1<:ColorAlpha, C2<:Color} = ColorAlpha
+_promote_alpha(::Type{C1}, ::Type{C2}) where {C1<:ColorAlpha, C2<:ColorAlpha} = ColorAlpha
+_promote_alpha(::Type{C1}, ::Type{C2}) where {C1<:ColorAlpha, C2<:AbstractAGray} = ColorAlpha
+_promote_alpha(::Type{C1}, ::Type{C2}) where {C1<:AbstractAGray, C2<:ColorAlpha} = ColorAlpha
+_promote_alpha(::Type{C1}, ::Type{C2}) where {C1<:Color, C2<:Color} = Color
 
-Base.promote_rule(::Type{C3}, ::Type{Cgray}) where {C3<:Transparent3,Cgray<:AbstractGray} = base_colorant_type(C3){promote_type(eltype(C3), eltype(Cgray))}
-Base.promote_rule(::Type{C3}, ::Type{Cgray}) where {C3<:Transparent3,Cgray<:TransparentGray} = base_colorant_type(C3){promote_type(eltype(C3), eltype(Cgray))}
+Base.promote_rule(::Type{C1}, ::Type{C2}) where {C1<:Colorant, C2<:Colorant} = _promote_rule(C1, C2)
+Base.promote_rule(::Type{C1}, ::Type{C2}) where {C1<:Color, C2<:TransparentColor} = Base.Bottom # to reduce rules
+
+Base.promote_rule(::Type{RGB24},   ::Type{Gray24})  = RGB24 # C vs. C
+Base.promote_rule(::Type{Gray24},  ::Type{RGB24})   = RGB24 # C vs. C
+Base.promote_rule(::Type{ARGB32},  ::Type{AGray32}) = ARGB32 # TC vs. TC
+Base.promote_rule(::Type{AGray32}, ::Type{ARGB32})  = ARGB32 # TC vs. TC
+Base.promote_rule(::Type{AGray32}, ::Type{Gray24})  = AGray32
+Base.promote_rule(::Type{AGray32}, ::Type{RGB24})   = ARGB32
+Base.promote_rule(::Type{ARGB32},  ::Type{Gray24})  = ARGB32
+Base.promote_rule(::Type{ARGB32},  ::Type{RGB24})   = ARGB32
+
+
+function _promote_rule(::Type{C1}, ::Type{C2}) where {C1<:Colorant, C2<:Colorant}
+    et, alpha = _promote_et(C1, C2), _promote_alpha(C1, C2)
+    Cp1, Cp2 = parametric_colorant(C1), parametric_colorant(C2)
+    color = _promote_color(base_color_type(Cp1), base_color_type(Cp2))
+
+    _with_et(C::UnionAll, et) = isconcretetype(et) ? C{et} : C
+    if !isabstracttype(color)
+        alpha <: Color && return _with_et(color, et)
+        c = color <: XRGB || color <: RGBX ? RGB : color
+        return _with_et(alpha <: ColorAlpha ? coloralpha(c) : alphacolor(c), et)
+    end
+
+    function _with_et(A::UnionAll, ::Type{Cb}, et) where {Nb, Cb<:ColorN{Nb}}
+        A <: Color && return isconcretetype(et) ? Color{et,Nb} : ColorN{Nb}
+        N = min(4, Nb + 1) # FIXME: N should be calculated based on C1 and C2
+        isconcretetype(et) ? A{C,et,N} where {C<:Cb{et}} : A{C,T,N} where {T, C<:Cb{T}}
+    end
+    function _with_et(A::UnionAll, ::Type{Cb}, et) where {Cb<:Color}
+        A <: Color && return isconcretetype(et) ? Color{et} : Color
+        isconcretetype(et) ? A{C,et} where {C<:Cb{et}} : A{C,T} where {T, C<:Cb{T}}
+    end
+    _with_et(alpha, color, et)
+end
+
 
 # no-op and element-type conversions, plus conversion to and from transparency
 # Colorimetry conversions are in Colors.jl

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -3,70 +3,138 @@ using Test
 using ColorTypes: ColorTypeResolutionError
 
 @testset "rgb promotions" begin
-    @test        promote( RGB{N0f8}(0.2,0.3,0.4),  RGB(0.3,0.8,0.1)) === ( RGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8),  RGB{Float64}(0.3,0.8,0.1))
-    @test_broken promote( RGB{N0f8}(0.2,0.3,0.4), RGBA(0.3,0.8,0.1)) === (RGBA{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), RGBA{Float64}(0.3,0.8,0.1))
-    @test_broken promote( RGB{N0f8}(0.2,0.3,0.4), ARGB(0.3,0.8,0.1)) === (ARGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), ARGB{Float64}(0.3,0.8,0.1))
-    @test_broken promote(RGBA{N0f8}(0.2,0.3,0.4),  RGB(0.3,0.8,0.1)) === (RGBA{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), RGBA{Float64}(0.3,0.8,0.1))
-    @test_broken promote(RGBA{N0f8}(0.2,0.3,0.4), RGBA(0.3,0.8,0.1)) === (RGBA{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), RGBA{Float64}(0.3,0.8,0.1))
-    @test_broken promote(ARGB{N0f8}(0.2,0.3,0.4),  RGB(0.3,0.8,0.1)) === (ARGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), ARGB{Float64}(0.3,0.8,0.1))
-    @test_broken promote(ARGB{N0f8}(0.2,0.3,0.4), ARGB(0.3,0.8,0.1)) === (ARGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), ARGB{Float64}(0.3,0.8,0.1))
+    @test promote( RGB{N0f8}(0.2,0.3,0.4),  RGB(0.3,0.8,0.1)) === ( RGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8),  RGB{Float64}(0.3,0.8,0.1))
+    @test promote( RGB{N0f8}(0.2,0.3,0.4), RGBA(0.3,0.8,0.1)) === (RGBA{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), RGBA{Float64}(0.3,0.8,0.1))
+    @test promote( RGB{N0f8}(0.2,0.3,0.4), ARGB(0.3,0.8,0.1)) === (ARGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), ARGB{Float64}(0.3,0.8,0.1))
+    @test promote(RGBA{N0f8}(0.2,0.3,0.4),  RGB(0.3,0.8,0.1)) === (RGBA{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), RGBA{Float64}(0.3,0.8,0.1))
+    @test promote(RGBA{N0f8}(0.2,0.3,0.4), RGBA(0.3,0.8,0.1)) === (RGBA{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), RGBA{Float64}(0.3,0.8,0.1))
+    @test promote(ARGB{N0f8}(0.2,0.3,0.4),  RGB(0.3,0.8,0.1)) === (ARGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), ARGB{Float64}(0.3,0.8,0.1))
+    @test promote(ARGB{N0f8}(0.2,0.3,0.4), ARGB(0.3,0.8,0.1)) === (ARGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), ARGB{Float64}(0.3,0.8,0.1))
 
-    @test        promote( RGB24(0.2,0.3,0.4),  RGB(0.3,0.8,0.1)) === ( RGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8),  RGB{Float64}(0.3,0.8,0.1))
-    @test_broken promote( RGB24(0.2,0.3,0.4), RGBA(0.3,0.8,0.1)) === (RGBA{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), RGBA{Float64}(0.3,0.8,0.1))
-    @test_broken promote( RGB24(0.2,0.3,0.4), ARGB(0.3,0.8,0.1)) === (ARGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), ARGB{Float64}(0.3,0.8,0.1))
-    @test_broken promote(ARGB32(0.2,0.3,0.4),  RGB(0.3,0.8,0.1)) === (ARGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), ARGB{Float64}(0.3,0.8,0.1))
-    @test_broken promote(ARGB32(0.2,0.3,0.4), ARGB(0.3,0.8,0.1)) === (ARGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), ARGB{Float64}(0.3,0.8,0.1))
+    @test promote( RGB24(0.2,0.3,0.4),  RGB(0.3,0.8,0.1)) === ( RGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8),  RGB{Float64}(0.3,0.8,0.1))
+    @test promote( RGB24(0.2,0.3,0.4), RGBA(0.3,0.8,0.1)) === (RGBA{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), RGBA{Float64}(0.3,0.8,0.1))
+    @test promote( RGB24(0.2,0.3,0.4), ARGB(0.3,0.8,0.1)) === (ARGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), ARGB{Float64}(0.3,0.8,0.1))
+    @test promote(ARGB32(0.2,0.3,0.4),  RGB(0.3,0.8,0.1)) === (ARGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), ARGB{Float64}(0.3,0.8,0.1))
+    @test promote(ARGB32(0.2,0.3,0.4), ARGB(0.3,0.8,0.1)) === (ARGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), ARGB{Float64}(0.3,0.8,0.1))
 
-    @test        promote( RGB24(0.2,0.3,0.4),  RGB{N0f8}(0.3,0.8,0.1)) === ( RGB{N0f8}(0.2,0.3,0.4),  RGB{N0f8}(0.3,0.8,0.1))
-    @test_broken promote( RGB24(0.2,0.3,0.4), RGBA{N0f8}(0.3,0.8,0.1)) === (RGBA{N0f8}(0.2,0.3,0.4), RGBA{N0f8}(0.3,0.8,0.1))
-    @test_broken promote( RGB24(0.2,0.3,0.4), ARGB{N0f8}(0.3,0.8,0.1)) === (ARGB{N0f8}(0.2,0.3,0.4), ARGB{N0f8}(0.3,0.8,0.1))
-    @test_broken promote(ARGB32(0.2,0.3,0.4),  RGB{N0f8}(0.3,0.8,0.1)) === (ARGB{N0f8}(0.2,0.3,0.4), ARGB{N0f8}(0.3,0.8,0.1))
-    @test_broken promote(ARGB32(0.2,0.3,0.4), ARGB{N0f8}(0.3,0.8,0.1)) === (ARGB{N0f8}(0.2,0.3,0.4), ARGB{N0f8}(0.3,0.8,0.1))
+    @test promote( RGB24(0.2,0.3,0.4),  RGB{N0f8}(0.3,0.8,0.1)) === ( RGB{N0f8}(0.2,0.3,0.4),  RGB{N0f8}(0.3,0.8,0.1))
+    @test promote( RGB24(0.2,0.3,0.4), RGBA{N0f8}(0.3,0.8,0.1)) === (RGBA{N0f8}(0.2,0.3,0.4), RGBA{N0f8}(0.3,0.8,0.1))
+    @test promote( RGB24(0.2,0.3,0.4), ARGB{N0f8}(0.3,0.8,0.1)) === (ARGB{N0f8}(0.2,0.3,0.4), ARGB{N0f8}(0.3,0.8,0.1))
+    @test promote(ARGB32(0.2,0.3,0.4),  RGB{N0f8}(0.3,0.8,0.1)) === (ARGB{N0f8}(0.2,0.3,0.4), ARGB{N0f8}(0.3,0.8,0.1))
+    @test promote(ARGB32(0.2,0.3,0.4), ARGB{N0f8}(0.3,0.8,0.1)) === (ARGB{N0f8}(0.2,0.3,0.4), ARGB{N0f8}(0.3,0.8,0.1))
 
-    @test_broken promote(RGBX{N0f8}(0.2,0.3,0.4),  RGB(0.3,0.8,0.1)) === (RGBX{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), RGBX{Float64}(0.3,0.8,0.1))
-    @test_broken promote(RGBX{N0f8}(0.2,0.3,0.4), RGBA(0.3,0.8,0.1)) === (RGBA{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), RGBA{Float64}(0.3,0.8,0.1))
-    @test_broken promote(RGBX{N0f8}(0.2,0.3,0.4), ARGB(0.3,0.8,0.1)) === (ARGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), ARGB{Float64}(0.3,0.8,0.1))
-    @test_broken promote(XRGB{N0f8}(0.2,0.3,0.4),  RGB(0.3,0.8,0.1)) === (XRGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), XRGB{Float64}(0.3,0.8,0.1))
-    @test_broken promote(XRGB{N0f8}(0.2,0.3,0.4), RGBA(0.3,0.8,0.1)) === (RGBA{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), RGBA{Float64}(0.3,0.8,0.1))
-    @test_broken promote(XRGB{N0f8}(0.2,0.3,0.4), ARGB(0.3,0.8,0.1)) === (ARGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), ARGB{Float64}(0.3,0.8,0.1))
+    @test promote(RGBX{N0f8}(0.2,0.3,0.4),  RGB(0.3,0.8,0.1)) === (RGBX{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), RGBX{Float64}(0.3,0.8,0.1))
+    @test promote(RGBX{N0f8}(0.2,0.3,0.4), RGBA(0.3,0.8,0.1)) === (RGBA{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), RGBA{Float64}(0.3,0.8,0.1))
+    @test promote(RGBX{N0f8}(0.2,0.3,0.4), ARGB(0.3,0.8,0.1)) === (ARGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), ARGB{Float64}(0.3,0.8,0.1))
+    @test promote(XRGB{N0f8}(0.2,0.3,0.4),  RGB(0.3,0.8,0.1)) === (XRGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), XRGB{Float64}(0.3,0.8,0.1))
+    @test promote(XRGB{N0f8}(0.2,0.3,0.4), RGBA(0.3,0.8,0.1)) === (RGBA{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), RGBA{Float64}(0.3,0.8,0.1))
+    @test promote(XRGB{N0f8}(0.2,0.3,0.4), ARGB(0.3,0.8,0.1)) === (ARGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), ARGB{Float64}(0.3,0.8,0.1))
 
-    @test_broken promote(RGBX(0.2,0.3,0.4),  RGB{N0f8}(0.3,0.8,0.1)) === (RGBX{Float64}(0.2,0.3,0.4), RGBX{Float64}(0.3N0f8,0.8N0f8,0.1N0f8))
-    @test_broken promote(RGBX(0.2,0.3,0.4), RGBA{N0f8}(0.3,0.8,0.1)) === (RGBA{Float64}(0.2,0.3,0.4), RGBA{Float64}(0.3N0f8,0.8N0f8,0.1N0f8))
-    @test_broken promote(RGBX(0.2,0.3,0.4), ARGB{N0f8}(0.3,0.8,0.1)) === (ARGB{Float64}(0.2,0.3,0.4), ARGB{Float64}(0.3N0f8,0.8N0f8,0.1N0f8))
-    @test_broken promote(XRGB(0.2,0.3,0.4),  RGB{N0f8}(0.3,0.8,0.1)) === (XRGB{Float64}(0.2,0.3,0.4), XRGB{Float64}(0.3N0f8,0.8N0f8,0.1N0f8))
-    @test_broken promote(XRGB(0.2,0.3,0.4), RGBA{N0f8}(0.3,0.8,0.1)) === (RGBA{Float64}(0.2,0.3,0.4), RGBA{Float64}(0.3N0f8,0.8N0f8,0.1N0f8))
-    @test_broken promote(XRGB(0.2,0.3,0.4), ARGB{N0f8}(0.3,0.8,0.1)) === (ARGB{Float64}(0.2,0.3,0.4), ARGB{Float64}(0.3N0f8,0.8N0f8,0.1N0f8))
+    @test promote(RGBX(0.2,0.3,0.4),  RGB{N0f8}(0.3,0.8,0.1)) === (RGBX{Float64}(0.2,0.3,0.4), RGBX{Float64}(0.3N0f8,0.8N0f8,0.1N0f8))
+    @test promote(RGBX(0.2,0.3,0.4), RGBA{N0f8}(0.3,0.8,0.1)) === (RGBA{Float64}(0.2,0.3,0.4), RGBA{Float64}(0.3N0f8,0.8N0f8,0.1N0f8))
+    @test promote(RGBX(0.2,0.3,0.4), ARGB{N0f8}(0.3,0.8,0.1)) === (ARGB{Float64}(0.2,0.3,0.4), ARGB{Float64}(0.3N0f8,0.8N0f8,0.1N0f8))
+    @test promote(XRGB(0.2,0.3,0.4),  RGB{N0f8}(0.3,0.8,0.1)) === (XRGB{Float64}(0.2,0.3,0.4), XRGB{Float64}(0.3N0f8,0.8N0f8,0.1N0f8))
+    @test promote(XRGB(0.2,0.3,0.4), RGBA{N0f8}(0.3,0.8,0.1)) === (RGBA{Float64}(0.2,0.3,0.4), RGBA{Float64}(0.3N0f8,0.8N0f8,0.1N0f8))
+    @test promote(XRGB(0.2,0.3,0.4), ARGB{N0f8}(0.3,0.8,0.1)) === (ARGB{Float64}(0.2,0.3,0.4), ARGB{Float64}(0.3N0f8,0.8N0f8,0.1N0f8))
+
+    @test promote(RGB24(0.2,0.3,0.4), ARGB32(0.3,0.8,0.1)) === (ARGB32(0.2,0.3,0.4), ARGB32(0.3,0.8,0.1))
+
+    @test promote_type(RGB, RGB) === RGB
+    @test promote_type(RGB, RGB{Float16}) === RGB
+
+    @test promote_type(RGB, RGBA) === RGBA
+    @test promote_type(ARGB, RGB) === ARGB
+    @test promote_type(RGB, RGBA{Float16}) === RGBA
+    @test promote_type(ARGB, RGB{Float16}) === ARGB
+
+    @test promote_type(RGBA, RGBA) === RGBA
+    @test promote_type(ARGB, ARGB) === ARGB
+    @test promote_type(ARGB, RGBA) === ARGB
+    @test promote_type(RGBA, RGBA{Float16}) === RGBA
+    @test promote_type(ARGB, ARGB{Float16}) === ARGB
+    @test promote_type(ARGB, RGBA{Float16}) === ARGB
+
+    @test promote_type(RGB, RGB24) === RGB
+    @test promote_type(BGR, RGB24) === RGB
+    @test promote_type(XRGB, RGB24) === XRGB
+    @test promote_type(RGBX, RGB24) === RGBX
+    @test promote_type(RGB, ARGB32) === ARGB
+    @test promote_type(BGR, ARGB32) === ARGB
+    @test promote_type(XRGB, ARGB32) === ARGB
+    @test promote_type(RGBX, ARGB32) === ARGB
+
+    @test promote_type(RGB, BGR) === RGB
+    @test promote_type(RGB, BGR{Float16}) === RGB
+    @test promote_type(BGR, RGB{Float16}) === RGB
+
+    @test promote_type(RGB, RGBX) === RGBX
+    @test promote_type(XRGB, RGB) === XRGB
+    @test promote_type(RGB, RGBX{Float16}) === RGBX
+    @test promote_type(XRGB, RGB{Float16}) === XRGB
+
+    @test promote_type(AbstractRGB, RGB{Float16}) === RGB
+    @test promote_type(RGB, AbstractRGB{Float16}) === RGB
+    @test promote_type(AbstractRGB{Float16}, RGB{Float16}) === RGB{Float16}
+    @test promote_type(AbstractRGB{Float16}, RGB24) === RGB{Float32}
 end
 
 @testset "hsv promotions" begin
-    @test_broken promote( HSV{Float32}(100,0.3,0.4),  HSV(200,0.8,0.1)) === ( HSV{Float64}(100,0.3f0,0.4f0),  HSV{Float64}(200,0.8,0.1))
-    @test_broken promote( HSV{Float32}(100,0.3,0.4), HSVA(200,0.8,0.1)) === (HSVA{Float64}(100,0.3f0,0.4f0), HSVA{Float64}(200,0.8,0.1))
-    @test_broken promote( HSV{Float32}(100,0.3,0.4), AHSV(200,0.8,0.1)) === (AHSV{Float64}(100,0.3f0,0.4f0), AHSV{Float64}(200,0.8,0.1))
-    @test_broken promote(HSVA{Float32}(100,0.3,0.4),  HSV(200,0.8,0.1)) === (HSVA{Float64}(100,0.3f0,0.4f0), HSVA{Float64}(200,0.8,0.1))
-    @test_broken promote(HSVA{Float32}(100,0.3,0.4), HSVA(200,0.8,0.1)) === (HSVA{Float64}(100,0.3f0,0.4f0), HSVA{Float64}(200,0.8,0.1))
-    @test_broken promote(AHSV{Float32}(100,0.3,0.4),  HSV(200,0.8,0.1)) === (AHSV{Float64}(100,0.3f0,0.4f0), AHSV{Float64}(200,0.8,0.1))
-    @test_broken promote(AHSV{Float32}(100,0.3,0.4), AHSV(200,0.8,0.1)) === (AHSV{Float64}(100,0.3f0,0.4f0), AHSV{Float64}(200,0.8,0.1))
+    @test promote( HSV{Float32}(100,0.3,0.4),  HSV(200,0.8,0.1)) === ( HSV{Float64}(100,0.3f0,0.4f0),  HSV{Float64}(200,0.8,0.1))
+    @test promote( HSV{Float32}(100,0.3,0.4), HSVA(200,0.8,0.1)) === (HSVA{Float64}(100,0.3f0,0.4f0), HSVA{Float64}(200,0.8,0.1))
+    @test promote( HSV{Float32}(100,0.3,0.4), AHSV(200,0.8,0.1)) === (AHSV{Float64}(100,0.3f0,0.4f0), AHSV{Float64}(200,0.8,0.1))
+    @test promote(HSVA{Float32}(100,0.3,0.4),  HSV(200,0.8,0.1)) === (HSVA{Float64}(100,0.3f0,0.4f0), HSVA{Float64}(200,0.8,0.1))
+    @test promote(HSVA{Float32}(100,0.3,0.4), HSVA(200,0.8,0.1)) === (HSVA{Float64}(100,0.3f0,0.4f0), HSVA{Float64}(200,0.8,0.1))
+    @test promote(AHSV{Float32}(100,0.3,0.4),  HSV(200,0.8,0.1)) === (AHSV{Float64}(100,0.3f0,0.4f0), AHSV{Float64}(200,0.8,0.1))
+    @test promote(AHSV{Float32}(100,0.3,0.4), AHSV(200,0.8,0.1)) === (AHSV{Float64}(100,0.3f0,0.4f0), AHSV{Float64}(200,0.8,0.1))
+
+    @test promote_type(HSV, HSV) === HSV
+    @test promote_type(HSV, HSV{Float16}) === HSV
+
+    @test promote_type(HSV, HSVA) === HSVA
+    @test promote_type(AHSV, HSV) === AHSV
+    @test promote_type(HSV, HSVA{Float16}) === HSVA
+    @test promote_type(AHSV, HSV{Float16}) === AHSV
 end
 
 @testset "gray promotions" begin
-    @test        promote( Gray{N0f8}(0.2),  Gray(0.3)) === ( Gray{Float64}(0.2N0f8),  Gray{Float64}(0.3))
-    @test_broken promote( Gray{N0f8}(0.2), GrayA(0.3)) === (GrayA{Float64}(0.2N0f8), GrayA{Float64}(0.3))
-    @test_broken promote( Gray{N0f8}(0.2), AGray(0.3)) === (AGray{Float64}(0.2N0f8), AGray{Float64}(0.3))
-    @test_broken promote(GrayA{N0f8}(0.2),  Gray(0.3)) === (GrayA{Float64}(0.2N0f8), GrayA{Float64}(0.3))
-    @test_broken promote(GrayA{N0f8}(0.2), GrayA(0.3)) === (GrayA{Float64}(0.2N0f8), GrayA{Float64}(0.3))
-    @test_broken promote(AGray{N0f8}(0.2),  Gray(0.3)) === (AGray{Float64}(0.2N0f8), AGray{Float64}(0.3))
-    @test_broken promote(AGray{N0f8}(0.2), AGray(0.3)) === (AGray{Float64}(0.2N0f8), AGray{Float64}(0.3))
+    @test promote( Gray{N0f8}(0.2),  Gray(0.3)) === ( Gray{Float64}(0.2N0f8),  Gray{Float64}(0.3))
+    @test promote( Gray{N0f8}(0.2), GrayA(0.3)) === (GrayA{Float64}(0.2N0f8), GrayA{Float64}(0.3))
+    @test promote( Gray{N0f8}(0.2), AGray(0.3)) === (AGray{Float64}(0.2N0f8), AGray{Float64}(0.3))
+    @test promote(GrayA{N0f8}(0.2),  Gray(0.3)) === (GrayA{Float64}(0.2N0f8), GrayA{Float64}(0.3))
+    @test promote(GrayA{N0f8}(0.2), GrayA(0.3)) === (GrayA{Float64}(0.2N0f8), GrayA{Float64}(0.3))
+    @test promote(AGray{N0f8}(0.2),  Gray(0.3)) === (AGray{Float64}(0.2N0f8), AGray{Float64}(0.3))
+    @test promote(AGray{N0f8}(0.2), AGray(0.3)) === (AGray{Float64}(0.2N0f8), AGray{Float64}(0.3))
 
-    @test        promote( Gray24(0.2),  Gray(0.3)) === ( Gray{Float64}(0.2N0f8),  Gray{Float64}(0.3))
-    @test_broken promote( Gray24(0.2), GrayA(0.3)) === (GrayA{Float64}(0.2N0f8), GrayA{Float64}(0.3))
-    @test_broken promote( Gray24(0.2), AGray(0.3)) === (AGray{Float64}(0.2N0f8), AGray{Float64}(0.3))
-    @test_broken promote(AGray32(0.2),  Gray(0.3)) === (AGray{Float64}(0.2N0f8), AGray{Float64}(0.3))
-    @test_broken promote(AGray32(0.2), AGray(0.3)) === (AGray{Float64}(0.2N0f8), AGray{Float64}(0.3))
-    @test        promote( Gray24(0.2),  Gray{N0f8}(0.3)) === ( Gray{N0f8}(0.2),  Gray{N0f8}(0.3))
-    @test_broken promote( Gray24(0.2), GrayA{N0f8}(0.3)) === (GrayA{N0f8}(0.2), GrayA{N0f8}(0.3))
-    @test_broken promote( Gray24(0.2), AGray{N0f8}(0.3)) === (AGray{N0f8}(0.2), AGray{N0f8}(0.3))
-    @test_broken promote(AGray32(0.2),  Gray{N0f8}(0.3)) === (AGray{N0f8}(0.2), AGray{N0f8}(0.3))
-    @test_broken promote(AGray32(0.2), AGray{N0f8}(0.3)) === (AGray{N0f8}(0.2), AGray{N0f8}(0.3))
+    @test promote( Gray24(0.2),  Gray(0.3)) === ( Gray{Float64}(0.2N0f8),  Gray{Float64}(0.3))
+    @test promote( Gray24(0.2), GrayA(0.3)) === (GrayA{Float64}(0.2N0f8), GrayA{Float64}(0.3))
+    @test promote( Gray24(0.2), AGray(0.3)) === (AGray{Float64}(0.2N0f8), AGray{Float64}(0.3))
+    @test promote(AGray32(0.2),  Gray(0.3)) === (AGray{Float64}(0.2N0f8), AGray{Float64}(0.3))
+    @test promote(AGray32(0.2), AGray(0.3)) === (AGray{Float64}(0.2N0f8), AGray{Float64}(0.3))
+    @test promote( Gray24(0.2),  Gray{N0f8}(0.3)) === ( Gray{N0f8}(0.2),  Gray{N0f8}(0.3))
+    @test promote( Gray24(0.2), GrayA{N0f8}(0.3)) === (GrayA{N0f8}(0.2), GrayA{N0f8}(0.3))
+    @test promote( Gray24(0.2), AGray{N0f8}(0.3)) === (AGray{N0f8}(0.2), AGray{N0f8}(0.3))
+    @test promote(AGray32(0.2),  Gray{N0f8}(0.3)) === (AGray{N0f8}(0.2), AGray{N0f8}(0.3))
+    @test promote(AGray32(0.2), AGray{N0f8}(0.3)) === (AGray{N0f8}(0.2), AGray{N0f8}(0.3))
+
+    @test promote(AGray32(0.2), Gray24(0.3)) === (AGray32(0.2N0f8), AGray32(0.3))
+
+    @test promote_type(Gray, Gray) === Gray
+    @test promote_type(Gray, Gray{Float16}) === Gray
+
+    @test promote_type(Gray, GrayA) === GrayA
+    @test promote_type(AGray, Gray) === AGray
+    @test promote_type(Gray, GrayA{Float16}) === GrayA
+    @test promote_type(AGray, Gray{Float16}) === AGray
+
+    @test promote_type(AGray, Gray{Bool}) === AGray
+
+    @test promote_type(Gray, Gray24) === Gray
+    @test promote_type(Gray, AGray32) === AGray
+
+    @test promote_type(AbstractGray, Gray{Float16}) === Gray
+    @test promote_type(Gray, AbstractGray{Float16}) === Gray
+    @test promote_type(AbstractGray{Float16}, Gray{Float16}) === Gray{Float16}
+    @test promote_type(AbstractGray{Float16}, Gray24) === Gray{Float32}
 end
 
 @testset "rgb and gray promotions" begin
@@ -100,12 +168,12 @@ end
     @test promote(ARGB(0.2,0.3,0.4), GrayA{N0f8}(0.8)) === (ARGB{Float64}(0.2,0.3,0.4,1), ARGB{Float64}(0.8N0f8,0.8N0f8,0.8N0f8,1))
     @test promote(ARGB(0.2,0.3,0.4), AGray{N0f8}(0.8)) === (ARGB{Float64}(0.2,0.3,0.4,1), ARGB{Float64}(0.8N0f8,0.8N0f8,0.8N0f8,1))
 
-    @test_broken promote( RGB24(0.2,0.3,0.4),  Gray(0.8)) === ( RGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8),  RGB{Float64}(0.8,0.8,0.8,0.1))
-    @test_broken promote( RGB24(0.2,0.3,0.4), GrayA(0.8)) === (RGBA{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), RGBA{Float64}(0.8,0.8,0.8,0.1))
-    @test_broken promote( RGB24(0.2,0.3,0.4), AGray(0.8)) === (ARGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), ARGB{Float64}(0.8,0.8,0.8,0.1))
-    @test_broken promote(ARGB32(0.2,0.3,0.4),  Gray(0.8)) === (ARGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), ARGB{Float64}(0.8,0.8,0.8,0.1))
-    @test_broken promote(ARGB32(0.2,0.3,0.4), GrayA(0.8)) === (ARGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), ARGB{Float64}(0.8,0.8,0.8,0.1))
-    @test_broken promote(ARGB32(0.2,0.3,0.4), AGray(0.8)) === (ARGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), ARGB{Float64}(0.8,0.8,0.8,0.1))
+    @test promote( RGB24(0.2,0.3,0.4),  Gray(0.8)) === (RGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), RGB{Float64}(0.8,0.8,0.8))
+    @test promote( RGB24(0.2,0.3,0.4), GrayA(0.8)) === (RGBA{Float64}(0.2N0f8,0.3N0f8,0.4N0f8,1), RGBA{Float64}(0.8,0.8,0.8,1))
+    @test promote( RGB24(0.2,0.3,0.4), AGray(0.8)) === (ARGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8,1), ARGB{Float64}(0.8,0.8,0.8,1))
+    @test promote(ARGB32(0.2,0.3,0.4),  Gray(0.8)) === (ARGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8,1), ARGB{Float64}(0.8,0.8,0.8,1))
+    @test promote(ARGB32(0.2,0.3,0.4), GrayA(0.8)) === (ARGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8,1), ARGB{Float64}(0.8,0.8,0.8,1))
+    @test promote(ARGB32(0.2,0.3,0.4), AGray(0.8)) === (ARGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8,1), ARGB{Float64}(0.8,0.8,0.8,1))
 
     @test promote( RGB(0.2,0.3,0.4),  Gray24(0.8)) === (RGB{Float64}(0.2,0.3,0.4), RGB{Float64}(0.8N0f8,0.8N0f8,0.8N0f8))
     @test promote( RGB(0.2,0.3,0.4), AGray32(0.8)) === (ARGB{Float64}(0.2,0.3,0.4,1), ARGB{Float64}(0.8N0f8,0.8N0f8,0.8N0f8,1))
@@ -114,14 +182,217 @@ end
     @test promote(ARGB(0.2,0.3,0.4),  Gray24(0.8)) === (ARGB{Float64}(0.2,0.3,0.4,1), ARGB{Float64}(0.8N0f8,0.8N0f8,0.8N0f8,1))
     @test promote(ARGB(0.2,0.3,0.4), AGray32(0.8)) === (ARGB{Float64}(0.2,0.3,0.4,1), ARGB{Float64}(0.8N0f8,0.8N0f8,0.8N0f8,1))
 
-    @test_broken promote( RGB24(0.2,0.3,0.4),  Gray24(0.8)) === (RGB24(0.2,0.3,0.4), RGB24(0.8,0.8,0.8))
-    @test_broken promote( RGB24(0.2,0.3,0.4), AGray32(0.8)) === (ARGB32(0.2,0.3,0.4,1), ARGB32(0.8,0.8,0.8,1))
-    @test_broken promote(ARGB32(0.2,0.3,0.4),  Gray24(0.8)) === (ARGB32(0.2,0.3,0.4,1), ARGB32(0.8,0.8,0.8,1))
-    @test_broken promote(ARGB32(0.2,0.3,0.4), AGray32(0.8)) === (ARGB32(0.2,0.3,0.4,1), ARGB32(0.8,0.8,0.8,1))
+    @test promote( RGB24(0.2,0.3,0.4),  Gray24(0.8)) === (RGB24(0.2,0.3,0.4), RGB24(0.8,0.8,0.8))
+    @test promote( RGB24(0.2,0.3,0.4), AGray32(0.8)) === (ARGB32(0.2,0.3,0.4,1), ARGB32(0.8,0.8,0.8,1))
+    @test promote(ARGB32(0.2,0.3,0.4),  Gray24(0.8)) === (ARGB32(0.2,0.3,0.4,1), ARGB32(0.8,0.8,0.8,1))
+    @test promote(ARGB32(0.2,0.3,0.4), AGray32(0.8)) === (ARGB32(0.2,0.3,0.4,1), ARGB32(0.8,0.8,0.8,1))
 
     @test promote(RGB(0.2,0.3,0.4), Gray{Bool}(1)) === (RGB{Float64}(0.2,0.3,0.4), RGB{Float64}(1,1,1))
     @test promote(RGB{N0f8}(0.2,0.3,0.4), Gray{Bool}(1)) === (RGB{N0f8}(0.2,0.3,0.4), RGB{N0f8}(1,1,1))
+
+    @test promote_type(RGB, Gray) === RGB
+    @test promote_type(RGB, Gray{Float16}) === RGB
+    @test promote_type(Gray, RGB{Float16}) === RGB
+
+    @test promote_type(RGB, GrayA) === RGBA
+    @test promote_type(AGray, RGB) === ARGB
+    @test promote_type(RGB, GrayA{Float16}) === RGBA
+    @test promote_type(AGray, RGB{Float16}) === ARGB
+
+    @test promote_type(Gray, RGBA) === RGBA
+    @test promote_type(ARGB, Gray) === ARGB
+    @test promote_type(Gray, RGBA{Float16}) === RGBA
+    @test promote_type(ARGB, Gray{Float16}) === ARGB
+
+    @test promote_type(RGB, Gray{Bool}) === RGB
+    @test promote_type(ARGB, Gray{Bool}) === ARGB
+    @test promote_type(RGBA, Gray{Bool}) === RGBA
+
+    @test promote_type(RGB, Gray24) === RGB
+    @test promote_type(RGBA, Gray24) === RGBA
+    @test promote_type(ARGB, AGray32) === ARGB
+    @test promote_type(RGB24, Gray) === RGB
+    @test promote_type(RGB24, GrayA) === RGBA
+    @test promote_type(ARGB32, Gray) === ARGB
+    @test promote_type(ARGB32, GrayA) === ARGB
+
+    @test promote_type(AbstractRGB, Gray{Float16}) === RGB
+    @test promote_type(RGB, AbstractGray{Float16}) === RGB
+    @test promote_type(AbstractRGB{Float16}, Gray{Float16}) === RGB{Float16}
+    @test promote_type(AbstractRGB{Float16}, Gray24) === RGB{Float32}
+
+    @test promote_type(AbstractGray, RGB{Float16}) === RGB
+    @test promote_type(Gray, AbstractRGB{Float16}) === RGB
+    @test promote_type(AbstractGray{Float16}, RGB{Float16}) === RGB{Float16}
+    @test promote_type(AbstractGray{Float16}, RGB24) === RGB{Float32}
+
+    @test promote_type(AbstractRGB, AGray{Float16}) === ARGB
+    @test promote_type(RGB, AbstractAGray{Gray{Float16},Float16}) === ARGB
+    @test promote_type(AbstractRGB{Float16}, AGray{Float16}) === ARGB{Float16}
+    @test promote_type(AbstractRGB{Float16}, AGray32) === ARGB{Float32}
+
+    @test promote_type(AbstractGray, ARGB{Float16}) === ARGB
+    @test promote_type(Gray, AbstractARGB{RGB{Float16},Float16}) === ARGB
+    @test promote_type(AbstractGray{Float16}, ARGB{Float16}) === ARGB{Float16}
+    @test promote_type(AbstractGray{Float16}, ARGB32) === ARGB{Float32}
+
+    @test promote_type(AbstractARGB, AGray{Float16}) === ARGB
+    @test promote_type(ARGB, AbstractAGray{Gray{Float16},Float16}) === ARGB
+    @test promote_type(AbstractARGB{RGB{Float16},Float16}, AGray{Float16}) === ARGB{Float16}
+    @test promote_type(AbstractARGB{RGB{Float16},Float16}, AGray32) === ARGB{Float32}
 end
+
+@testset "hsv and gray promotions" begin
+    @test promote_type( HSV{Float16},  Gray{N0f8}) === HSV{Float32}
+    @test promote_type( HSV{Float16}, GrayA{N0f8}) === HSVA{Float32}
+    @test promote_type( HSV{Float16}, AGray{N0f8}) === AHSV{Float32}
+    @test promote_type(HSVA{Float16},  Gray{N0f8}) === HSVA{Float32}
+    @test promote_type(HSVA{Float16}, GrayA{N0f8}) === HSVA{Float32}
+    @test promote_type(HSVA{Float16}, AGray{N0f8}) === HSVA{Float32}
+    @test promote_type(AHSV{Float16},  Gray{N0f8}) === AHSV{Float32}
+    @test promote_type(AHSV{Float16}, GrayA{N0f8}) === AHSV{Float32}
+    @test promote_type(AHSV{Float16}, AGray{N0f8}) === AHSV{Float32}
+
+    @test promote_type( HSV{Float16},  Gray24) === HSV{Float32}
+    @test promote_type( HSV{Float16}, AGray32) === AHSV{Float32}
+    @test promote_type(HSVA{Float16},  Gray24) === HSVA{Float32}
+    @test promote_type(HSVA{Float16}, AGray32) === HSVA{Float32}
+    @test promote_type(AHSV{Float16},  Gray24) === AHSV{Float32}
+    @test promote_type(AHSV{Float16}, AGray32) === AHSV{Float32}
+
+    @test promote_type(HSV{Float64}, Gray{Bool}) === HSV{Float64}
+    @test promote_type(HSV{Float32}, Gray{Bool}) === HSV{Float32}
+
+    @test promote_type(HSV, Gray) === HSV
+    @test promote_type(HSV, Gray{Float16}) === HSV
+    @test promote_type(Gray, HSV{Float16}) === HSV
+
+    @test promote_type(HSV, GrayA) === HSVA
+    @test promote_type(AGray, HSV) === AHSV
+    @test promote_type(HSV, GrayA{Float16}) === HSVA
+    @test promote_type(AGray, HSV{Float16}) === AHSV
+
+    @test promote_type(Gray, HSVA) === HSVA
+    @test promote_type(AHSV, Gray) === AHSV
+    @test promote_type(Gray, HSVA{Float16}) === HSVA
+    @test promote_type(AHSV, Gray{Float16}) === AHSV
+
+    @test promote_type(GrayA, HSVA) === HSVA
+    @test promote_type(AHSV, AGray) === AHSV
+    @test promote_type(AGray, HSVA) === HSVA
+    @test promote_type(AHSV, GrayA) === AHSV
+
+    @test promote_type( HSV,  Gray24) === HSV
+    @test promote_type( HSV, AGray32) === AHSV
+    @test promote_type(HSVA,  Gray24) === HSVA
+    @test promote_type(HSVA, AGray32) === HSVA
+    @test promote_type(AHSV,  Gray24) === AHSV
+    @test promote_type(AHSV, AGray32) === AHSV
+end
+
+# promotions between different color spaces
+@testset "rgb and hsv promotions" begin
+    # the current implementation is like `typejoin`.
+    @test promote_type( RGB{Float64},  HSV{Float64}) == Color3{Float64}
+    @test promote_type( RGB{Float64}, HSVA{Float64}) == ColorAlpha{C,Float64,4} where {C<:Color3{Float64}}
+    @test promote_type( RGB{Float64}, AHSV{Float64}) == AlphaColor{C,Float64,4} where {C<:Color3{Float64}}
+    @test promote_type(RGBA{Float64},  HSV{Float64}) == ColorAlpha{C,Float64,4} where {C<:Color3{Float64}}
+    @test promote_type(RGBA{Float64}, HSVA{Float64}) == ColorAlpha{C,Float64,4} where {C<:Color3{Float64}}
+    @test promote_type(RGBA{Float64}, AHSV{Float64}) == AlphaColor{C,Float64,4} where {C<:Color3{Float64}}
+    @test promote_type(ARGB{Float64},  HSV{Float64}) == AlphaColor{C,Float64,4} where {C<:Color3{Float64}}
+    @test promote_type(ARGB{Float64}, HSVA{Float64}) == AlphaColor{C,Float64,4} where {C<:Color3{Float64}}
+    @test promote_type(ARGB{Float64}, AHSV{Float64}) == AlphaColor{C,Float64,4} where {C<:Color3{Float64}}
+
+    @test promote_type( RGB{N0f8},  HSV{Float16}) == Color3{Float32}
+    @test promote_type( RGB{N0f8}, HSVA{Float16}) == ColorAlpha{C,Float32,4} where {C<:Color3{Float32}}
+    @test promote_type( RGB{N0f8}, AHSV{Float16}) == AlphaColor{C,Float32,4} where {C<:Color3{Float32}}
+    @test promote_type(RGBA{N0f8},  HSV{Float16}) == ColorAlpha{C,Float32,4} where {C<:Color3{Float32}}
+    @test promote_type(RGBA{N0f8}, HSVA{Float16}) == ColorAlpha{C,Float32,4} where {C<:Color3{Float32}}
+    @test promote_type(RGBA{N0f8}, AHSV{Float16}) == AlphaColor{C,Float32,4} where {C<:Color3{Float32}}
+    @test promote_type(ARGB{N0f8},  HSV{Float16}) == AlphaColor{C,Float32,4} where {C<:Color3{Float32}}
+    @test promote_type(ARGB{N0f8}, HSVA{Float16}) == AlphaColor{C,Float32,4} where {C<:Color3{Float32}}
+    @test promote_type(ARGB{N0f8}, AHSV{Float16}) == AlphaColor{C,Float32,4} where {C<:Color3{Float32}}
+
+    @test promote_type( RGB24,  HSV{Float16}) == Color3{Float32}
+    @test promote_type( RGB24, HSVA{Float16}) == ColorAlpha{C,Float32,4} where {C<:Color3{Float32}}
+    @test promote_type( RGB24, AHSV{Float16}) == AlphaColor{C,Float32,4} where {C<:Color3{Float32}}
+    @test promote_type(ARGB32,  HSV{Float16}) == AlphaColor{C,Float32,4} where {C<:Color3{Float32}}
+    @test promote_type(ARGB32, HSVA{Float16}) == AlphaColor{C,Float32,4} where {C<:Color3{Float32}}
+    @test promote_type(ARGB32, AHSV{Float16}) == AlphaColor{C,Float32,4} where {C<:Color3{Float32}}
+
+    @test promote_type(RGB, HSV) == Color3
+    @test promote_type(RGB, HSV{Float16}) == Color3
+    @test promote_type(HSV, RGB{Float16}) == Color3
+
+    @test promote_type(RGB, HSVA) == ColorAlpha{C,T,4} where {T, C<:Color3{T}}
+    @test promote_type(AHSV, RGB) == AlphaColor{C,T,4} where {T, C<:Color3{T}}
+    @test promote_type(RGB, HSVA{Float16}) == ColorAlpha{C,T,4} where {T, C<:Color3{T}}
+    @test promote_type(AHSV, RGB{Float16}) == AlphaColor{C,T,4} where {T, C<:Color3{T}}
+
+    @test promote_type(HSV, RGBA) == ColorAlpha{C,T,4} where {T, C<:Color3{T}}
+    @test promote_type(ARGB, HSV) == AlphaColor{C,T,4} where {T, C<:Color3{T}}
+    @test promote_type(HSV, RGBA{Float16}) == ColorAlpha{C,T,4} where {T, C<:Color3{T}}
+    @test promote_type(ARGB, HSV{Float16}) == AlphaColor{C,T,4} where {T, C<:Color3{T}}
+
+    @test promote_type(HSVA, RGBA) == ColorAlpha{C,T,4} where {T, C<:Color3{T}}
+    @test promote_type(ARGB, AHSV) == AlphaColor{C,T,4} where {T, C<:Color3{T}}
+    @test promote_type(HSVA, RGBA{Float16}) == ColorAlpha{C,T,4} where {T, C<:Color3{T}}
+    @test promote_type(ARGB, AHSV{Float16}) == AlphaColor{C,T,4} where {T, C<:Color3{T}}
+
+    @test promote_type(AHSV, RGBA) == AlphaColor{C,T,4} where {T, C<:Color3{T}} # != Transparent3
+    @test promote_type(ARGB, HSVA) == AlphaColor{C,T,4} where {T, C<:Color3{T}} # != Transparent3
+    @test promote_type(AHSV, RGBA{Float16}) == AlphaColor{C,T,4} where {T, C<:Color3{T}} # != Transparent3
+    @test promote_type(ARGB, HSVA{Float16}) == AlphaColor{C,T,4} where {T, C<:Color3{T}} # != Transparent3
+
+    @test promote_type(RGB24, HSV) == Color3
+    @test promote_type(RGB24, HSVA{Float16}) == ColorAlpha{C,Float32,4} where C<:Color3{Float32}
+    @test promote_type(ARGB32, HSV) == AlphaColor{C,T,4} where {T, C<:Color3{T}}
+    @test promote_type(ARGB32, HSVA{Float16}) == AlphaColor{C,Float32,4} where C<:Color3{Float32}
+end
+
+@testset "promotions with abstract types" begin
+    @test promote_type(Colorant, RGB{Float64}) == AlphaColor{C,T} where {T, C<:Color{T}}
+    @test promote_type(Colorant{N0f8}, RGB{Float64}) == AlphaColor{C,Float64} where {C<:Color{Float64}}
+    @test promote_type(Colorant{Float32,3}, RGB{Float64}) == AlphaColor{C,Float64,4} where C<:Color{Float64,3}
+    @test promote_type(Color, RGB{Float64}) === Color
+    @test promote_type(Color{N0f8}, RGB{Float64}) === Color{Float64}
+    @test promote_type(Color{Float32,3}, RGB{Float64}) === Color{Float64,3}
+    @test promote_type(AbstractRGB, RGB{Float64}) === RGB
+    @test promote_type(AbstractRGB{N0f8}, RGB{Float64}) === RGB{Float64}
+    @test promote_type(TransparentColor, RGB{Float64}) == AlphaColor{C,T} where {T, C<:Color{T}}
+    @test promote_type(TransparentColor{RGB{N0f8}}, RGB{Float64}) === ARGB
+    @test promote_type(TransparentColor{RGB{N0f8},N0f8}, RGB{Float64}) === ARGB{Float64}
+    @test promote_type(TransparentColor{RGB{N0f8},N0f8,4}, RGB{Float64}) === ARGB{Float64}
+    @test promote_type(AlphaColor, RGB{Float64}) == AlphaColor{C,T} where {T, C<:Color{T}}
+    @test promote_type(AlphaColor{RGB{N0f8}}, RGB{Float64}) === ARGB
+    @test promote_type(AlphaColor{RGB{N0f8},N0f8}, RGB{Float64}) === ARGB{Float64}
+    @test promote_type(AlphaColor{RGB{N0f8},N0f8,4}, RGB{Float64}) === ARGB{Float64}
+    @test promote_type(ColorAlpha, RGB{Float64}) === ColorAlpha{C,T} where {T, C<:Color{T}}
+    @test promote_type(ColorAlpha{RGB{N0f8}}, RGB{Float64}) === RGBA
+    @test promote_type(ColorAlpha{RGB{N0f8},N0f8}, RGB{Float64}) === RGBA{Float64}
+    @test promote_type(ColorAlpha{RGB{N0f8},N0f8,4}, RGB{Float64}) === RGBA{Float64}
+
+    @test promote_type(Colorant, ARGB{Float64}) == AlphaColor{C,T} where {T, C<:Color{T}}
+    @test promote_type(Colorant{N0f8}, ARGB{Float64}) == AlphaColor{C,Float64} where C<:Color{Float64}
+    @test_broken promote_type(Colorant{Float32,4}, ARGB{Float64}) == AlphaColor{C,Float64,4} where C<:Color3{Float64}
+    @test promote_type(Color, ARGB{Float64}) == AlphaColor{C,T} where {T, C<:Color{T}}
+    @test promote_type(AbstractRGB, ARGB{Float64}) === ARGB
+    @test promote_type(AbstractRGB{N0f8}, ARGB{Float64}) === ARGB{Float64}
+    @test promote_type(TransparentColor, ARGB{Float64}) == AlphaColor{C,T} where {T, C<:Color{T}}
+    @test promote_type(AlphaColor, ARGB{Float64}) == AlphaColor{C,T} where {T, C<:Color{T}}
+    @test promote_type(ColorAlpha, ARGB{Float64}) == AlphaColor{C,T} where {T, C<:Color{T}}
+
+    @test promote_type(Colorant, RGBA{Float64}) == AlphaColor{C,T} where {T, C<:Color{T}}
+    @test promote_type(Colorant{N0f8}, RGBA{Float64}) == AlphaColor{C,Float64} where C<:Color{Float64}
+    @test promote_type(Colorant{Float32,3}, RGBA{Float64}) == AlphaColor{C,Float64,4} where C<:Color3{Float64}
+    @test promote_type(Color, RGBA{Float64}) == ColorAlpha{C,T} where {T, C<:Color{T}}
+    @test promote_type(AbstractRGB, RGBA{Float64}) === RGBA
+    @test promote_type(AbstractRGB{N0f8}, RGBA{Float64}) === RGBA{Float64}
+    @test promote_type(TransparentColor, RGBA{Float64}) == AlphaColor{C,T} where {T, C<:Color{T}}
+    @test promote_type(AlphaColor, RGBA{Float64}) == AlphaColor{C,T} where {T, C<:Color{T}}
+    @test promote_type(ColorAlpha, RGBA{Float64}) == ColorAlpha{C,T} where {T, C<:Color{T}}
+end
+
 
 @testset "rgb conversions with abstract types" begin
     c = RGB(1, 0.6, 0)
@@ -130,13 +401,13 @@ end
     @test convert(Colorant{Float32,3}, c) === RGB{Float32}(1, 0.6, 0)
     @test convert(Color, c) === RGB{Float64}(1, 0.6, 0)
     @test convert(Color{N0f8}, c) === RGB{N0f8}(1, 0.6, 0)
-    @test convert(Color{Float32}, c) === RGB{Float32}(1, 0.6, 0)
+    @test convert(Color{Float32,3}, c) === RGB{Float32}(1, 0.6, 0)
     @test convert(AbstractRGB, c) === RGB{Float64}(1, 0.6, 0)
     @test convert(AbstractRGB{N0f8}, c) === RGB{N0f8}(1, 0.6, 0)
     @test_throws ColorTypeResolutionError convert(TransparentColor, c)
     @test_throws ColorTypeResolutionError convert(TransparentColor{RGB{N0f8}}, c)
     @test_throws ColorTypeResolutionError convert(TransparentColor{RGB{N0f8},N0f8}, c)
-    @test_throws ColorTypeResolutionError convert(TransparentColor{RGB{N0f8},N0f8,2}, c)
+    @test_throws ColorTypeResolutionError convert(TransparentColor{RGB{N0f8},N0f8,4}, c)
     @test convert(AlphaColor, c) === ARGB{Float64}(1, 0.6, 0, 1)
     @test_broken convert(AlphaColor{RGB{N0f8}}, c) === ARGB{N0f8}(1, 0.6, 0, 1)
     @test convert(AlphaColor{RGB{N0f8},N0f8}, c) === ARGB{N0f8}(1, 0.6, 0, 1)
@@ -153,7 +424,7 @@ end
     @test convert(Color, ac) === RGB{Float64}(1, 0.6, 0)
     @test convert(AbstractRGB, ac) === RGB{Float64}(1, 0.6, 0)
     @test convert(AbstractRGB{N0f8}, ac) === RGB{N0f8}(1, 0.6, 0)
-    @test convert(TransparentColor, ac) == ARGB{Float64}(1, 0.6, 0, 0.8)
+    @test convert(TransparentColor, ac) === ARGB{Float64}(1, 0.6, 0, 0.8)
     @test convert(AlphaColor, ac) === ARGB{Float64}(1, 0.6, 0, 0.8) # issue #126
     @test convert(ColorAlpha, ac) === RGBA{Float64}(1, 0.6, 0, 0.8) # issue #126
 
@@ -164,7 +435,7 @@ end
     @test convert(Color, ca) === RGB{Float64}(1, 0.6, 0)
     @test convert(AbstractRGB, ca) === RGB{Float64}(1, 0.6, 0)
     @test convert(AbstractRGB{N0f8}, ca) === RGB{N0f8}(1, 0.6, 0)
-    @test convert(TransparentColor, ca) == RGBA{Float64}(1, 0.6, 0, 0.8)
+    @test convert(TransparentColor, ca) === RGBA{Float64}(1, 0.6, 0, 0.8)
     @test convert(AlphaColor, ca) === ARGB{Float64}(1, 0.6, 0, 0.8) # issue #126
     @test convert(ColorAlpha, ca) === RGBA{Float64}(1, 0.6, 0, 0.8) # issue #126
 


### PR DESCRIPTION
This PR is an alternative solution of PR #164.
The notable difference is that the rules implemented in this PR promote `AlphaColor` and `ColorAlpha` to `AlphaColor` instead of `TransparentColor`. (cf. https://github.com/JuliaGraphics/ColorTypes.jl/issues/129#issuecomment-589990753)