### PR TITLE
Fix RGB24/ARGB32 conversions (Fixes #163)

### DIFF
--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -72,34 +72,24 @@ end
 convert(::Type{C}, c::C) where {C<:Colorant} = c
 convert(::Type{C}, c) where {C<:Colorant} = cconvert(ccolor(C, typeof(c)), c)
 cconvert(::Type{C}, c::C) where {C} = c
-cconvert(::Type{C}, c) where {C}    = _convert(C, base_color_type(C), base_color_type(c), c)
+cconvert(::Type{C}, c) where {C} = _convert(C, base_color_type(C), base_color_type(c), c)
+
 convert(::Type{C}, c::Color, alpha) where {C<:TransparentColor} = cconvert(ccolor(C, typeof(c)), c, alpha)
-cconvert(::Type{AlphaColor{C,T,N}}, c::C, alpha) where {C<:Color,T,N} = alphacolor(C)(c, alpha)
-cconvert(::Type{ColorAlpha{C,T,N}}, c::C, alpha) where {C<:Color,T,N} = coloralpha(C)(c, alpha)
 cconvert(::Type{C}, c::Color, alpha) where {C<:TransparentColor} =_convert(C, base_color_type(C), base_color_type(c), c, alpha)
+cconvert(::Type{ARGB32}, c::AbstractRGB, alpha) = ARGB32(c, alpha) # optimization for speed
 
 # Fallback definitions that print nice error messages
 _convert(::Type{C}, ::Any, ::Any, c) where {C} = error("No conversion of ", c, " to ", C, " has been defined")
 _convert(::Type{C}, C1::Any, C2::Any, c, alpha) where {C} = error("No conversion of (", c, ",alpha=$alpha) to ", C, " with consistency-types $C1 and $C2 has been defined")
 
 # Any AbstractRGB types can be interconverted
-# (the first 2 are just for ambiguity resolution)
-# Note: on julia 0.3 these have to be before the block below, or you
-# get a spurious ambiguity warning.
-_convert(::Type{Cout}, ::Type{C1}, ::Type{C1}, c) where {Cout<:AbstractRGB,C1<:AbstractRGB} = Cout(red(c), green(c), blue(c))
-_convert(::Type{A}, ::Type{C1}, ::Type{C1}, c) where {A<:TransparentRGB,C1<:AbstractRGB} = A(red(c), green(c), blue(c), alpha(c))
 _convert(::Type{Cout}, ::Type{C1}, ::Type{C2}, c) where {Cout<:AbstractRGB,C1<:AbstractRGB,C2<:AbstractRGB} = Cout(red(c), green(c), blue(c))
-_convert(::Type{A}, ::Type{C1}, ::Type{C2}, c) where {A<:TransparentRGB,C1<:AbstractRGB,C2<:AbstractRGB} = A(red(c), green(c), blue(c), alpha(c))
+_convert(::Type{A}, ::Type{C1}, ::Type{C2}, c, alpha=alpha(c)) where {A<:TransparentRGB,C1<:AbstractRGB,C2<:AbstractRGB} = A(red(c), green(c), blue(c), alpha)
 
 # Implementations for when the base color type is not changing
 # These might trip/add transparency, however
 _convert(::Type{Cout}, ::Type{Ccmp}, ::Type{Ccmp}, c) where {Cout<:Color3,Ccmp<:Color3} = Cout(comp1(c), comp2(c), comp3(c))
-_convert(::Type{A}, ::Type{Ccmp}, ::Type{Ccmp}, c) where {A<:Transparent3,Ccmp<:Color3} = A(comp1(c), comp2(c), comp3(c), alpha(c))
-_convert(::Type{Cout}, ::Type{Ccmp}, ::Type{Ccmp}, c) where {Cout<:AbstractGray,Ccmp<:AbstractGray} = Cout(gray(c))
-_convert(::Type{A}, ::Type{Ccmp}, ::Type{Ccmp}, c) where {A<:TransparentGray,Ccmp<:AbstractGray} = A(gray(c), alpha(c))
-
-# With user-supplied alpha
-_convert(::Type{A}, ::Type{Ccmp}, ::Type{Ccmp}, c, alpha) where {A<:Transparent3,Ccmp<:Color3} = A(comp1(c), comp2(c), comp3(c), alpha)
+_convert(::Type{A}, ::Type{Ccmp}, ::Type{Ccmp}, c, alpha=alpha(c)) where {A<:Transparent3,Ccmp<:Color3} = A(comp1(c), comp2(c), comp3(c), alpha)
 
 # Grayscale
 _convert(::Type{Cout}, ::Type{C1}, ::Type{C2}, c) where {Cout<:AbstractGray,C1<:AbstractGray,C2<:AbstractGray} = Cout(gray(c))

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -35,8 +35,6 @@ gray(c::Gray24)  = N0f8(c.color & 0x000000ff, 0)
 gray(c::AGray32) = N0f8(c.color & 0x000000ff, 0)
 gray(x::Number)  = x
 
-Base.real(g::Gray) = gray(g)
-
 """
 `chroma(c)` returns the chroma of a `Lab`, `Luv` or their variants color.
 !!! note
@@ -482,12 +480,6 @@ end
 ==(c1::YIQ, c2::YIQ) = c1.y == c2.y && c1.i == c2.i && c1.q == c2.q
 ==(c1::YCbCr, c2::YCbCr) = c1.y == c2.y && c1.cb == c2.cb && c1.cr == c2.cr
 
-for T in (RGB24, ARGB32, Gray24, AGray32)
-    @eval begin
-        reinterpret(::Type{UInt32}, x::$T) = x.color
-        reinterpret(::Type{$T}, x::UInt32) = $T(x, Val{true})
-    end
-end
 ==(x::AbstractGray, y::AbstractGray) = gray(x) == gray(y)
 ==(x::Number, y::AbstractGray) = x == gray(y)
 ==(x::AbstractGray, y::Number) = ==(y, x)

--- a/src/types.jl
+++ b/src/types.jl
@@ -346,6 +346,7 @@ _ARGB32(r::UInt8, g::UInt8, b::UInt8, alpha::UInt8) = reinterpret(ARGB32, UInt32
 ARGB32(r::N0f8, g::N0f8, b::N0f8, alpha::N0f8 = N0f8(1)) = _ARGB32(reinterpret(r), reinterpret(g), reinterpret(b), reinterpret(alpha))
 ARGB32(r, g, b, alpha = 1) = ARGB32(N0f8(r), N0f8(g), N0f8(b), N0f8(alpha))
 ARGB32(c::AbstractRGB{T}, alpha = alpha(c)) where {T} = ARGB32(red(c), green(c), blue(c), alpha)
+ARGB32(c::RGB24, alpha = N0f8(1)) = reinterpret(ARGB32, (UInt32(reinterpret(N0f8(alpha))) << 24) | reinterpret(UInt32, c) & 0xFFFFFF)
 
 """
 `Gray` is a grayscale object. You can extract its value with `gray(c)`.

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -534,6 +534,9 @@ end
 
     @test convert(N0f8, Gray24(0.6)) === N0f8(0.6)
     @test convert(Float64, Gray24(0.6)) === 0.6
+    @test Float32(Gray24(0.6)) === 0.6f0
+    @test float(Gray24(0.6)) === 0.6
+    @test real(Gray24(0.6)) === N0f8(0.6)
 
     @test convert(Gray, 0.6) === Gray{Float64}(0.6)
     @test convert(Gray, 0.6f0) === Gray{Float32}(0.6)
@@ -571,6 +574,7 @@ end
 
     @test convert(RGB24, 0.6) === RGB24(0.6, 0.6, 0.6)
     @test convert(ARGB32, 0.6) === ARGB32(0.6, 0.6, 0.6, 1)
+    @test convert(ARGB32, 0.6, 0.8) === ARGB32(0.6, 0.6, 0.6, 0.8)
 
     @test convert(RGB, 0.6) === RGB(0.6, 0.6, 0.6)
 end
@@ -778,6 +782,37 @@ end
     @test_throws MethodError coloralpha(AGray32(0.6), 0.8)
 end
 
+@testset "reinterpret" begin
+    @test reinterpret(UInt32, RGB24()) === 0x00000000
+    @test reinterpret(UInt32, ARGB32()) === 0xff000000
+    @test reinterpret(UInt32, Gray24()) === 0x00000000
+    @test reinterpret(UInt32, AGray32()) === 0xff000000
+
+    @test reinterpret(UInt32, RGB24(0.071,0.204,0.337)) === 0x00123456
+    @test reinterpret(UInt32, ARGB32(0.071,0.204,0.337,0.671)) === 0xab123456
+    @test reinterpret(UInt32, Gray24(0.071)) === 0x00121212
+    @test reinterpret(UInt32, AGray32(0.071, 0.671)) === 0xab121212
+
+    @test reinterpret(RGB24, 0x00123456) === RGB24(0.071,0.204,0.337)
+    @test reinterpret(RGB24, 0xdc123456) ==  RGB24(0.071,0.204,0.337)
+    @test reinterpret(RGB24, 0x00123456) !== reinterpret(RGB24, 0xdc123456)
+    @test reinterpret(UInt32, reinterpret(RGB24, 0xdc123456)) === 0xdc123456
+
+    @test reinterpret(ARGB32, 0xab123456) === ARGB32(0.071,0.204,0.337,0.671)
+
+    @test reinterpret(Gray24, 0x00121212) === Gray24(0.071)
+    @test reinterpret(Gray24, 0xdc121212) ==  Gray24(0.071)
+    @test reinterpret(Gray24, 0x00121212) !== reinterpret(Gray24, 0xdc121212)
+    @test reinterpret(UInt32, reinterpret(Gray24, 0xdc121212)) === 0xdc121212
+    # the following behavior is undefined, so this is just for the regression test.
+    @test reinterpret(Gray24, 0xdc00ff12) ==  Gray24(0.071)
+    @test reinterpret(UInt32, reinterpret(Gray24, 0xdc00ff12)) === 0xdc00ff12
+
+    @test reinterpret(AGray32, 0xab121212) === AGray32(0.071, 0.671)
+
+    @test_throws MethodError reinterpret(UInt32, ARGB{N0f8}())
+    @test_throws ErrorException reinterpret(ARGB{N0f8}, 0x12345678)
+end
 
 ### Prevent ambiguous definitions
 

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -463,11 +463,11 @@ end
 
     @test convert(AbstractARGB{RGB,N0f8}, c, 0.2) === ARGB{N0f8}(1, 0.6, 0, 0.2)
     @test convert(AbstractRGBA{RGB,N0f8}, c, 0.2) === RGBA{N0f8}(1, 0.6, 0, 0.2)
-    @test convert(AbstractARGB{RGB24,N0f8}, rgb24, 0.2) === ARGB32(1, 0.6, 0, 0.2)
+    @test convert(AbstractARGB{RGB,N0f8}, rgb24, 0.2) === ARGB{N0f8}(1, 0.6, 0, 0.2)
     @test_throws MethodError convert(AbstractARGB{RGB,N0f8}, ac, 0.2)
     @test_throws MethodError convert(AbstractARGB{RGB,N0f8}, ca, 0.2)
-    @test_throws ErrorException convert(AbstractARGB{RGB,N0f8}, rgb24, 0.2)
     @test_throws MethodError convert(AbstractARGB{RGB,N0f8}, argb32, 0.2)
+    @test convert(AbstractARGB{RGB24,N0f8}, rgb24, 0.2) === ARGB32(1, 0.6, 0, 0.2)
 end
 
 @testset "gray conversions with abstract types" begin
@@ -589,13 +589,13 @@ end
         @test convert(RGB24, C(1,0.6,0)) === RGB24(1,0.6,0)
         @test convert(C, ARGB32(1,0.6,0,0.8)) === C{N0f8}(1,0.6,0)
         @test convert(ARGB32, C(1,0.6,0)) === ARGB32(1,0.6,0)
-        @test_broken convert(ARGB32, C(1,0.6,0), 0.2) === ARGB32(1,0.6,0,0.2)
+        @test convert(ARGB32, C(1,0.6,0), 0.2) === ARGB32(1,0.6,0,0.2)
     end
     @testset "$C conversions" for C in Ctransparent
         @test convert(C, C{Float64}(1,0.6,0,0.8)) === C{Float64}(1,0.6,0,0.8)
         @test convert(C{N0f8}, C{Float64}(1,0.6,0,0.8)) === C{N0f8}(1,0.6,0,0.8)
         @test convert(C, RGB24(1,0.6,0)) === C{N0f8}(1,0.6,0,1)
-        @test_broken convert(C, RGB24(1,0.6,0), 0.2) === C{N0f8}(1,0.6,0,0.2)
+        @test convert(C, RGB24(1,0.6,0), 0.2) === C{N0f8}(1,0.6,0,0.2)
         @test convert(RGB24, C(1,0.6,0,0.8)) === RGB24(1,0.6,0)
         @test convert(C, ARGB32(1,0.6,0,0.8)) === C{N0f8}(1,0.6,0,0.8)
         @test convert(ARGB32, C(1,0.6,0,0.8)) === ARGB32(1,0.6,0,0.8)

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -558,39 +558,6 @@ end
     @test_throws MethodError ccolor(RGB, RGB{N0f8}(1,0,0))
 end
 
-# TODO: move `reinterpret` to `conversions.jl`
-@testset "reinterpret" begin
-    @test reinterpret(UInt32, RGB24()) === 0x00000000
-    @test reinterpret(UInt32, ARGB32()) === 0xff000000
-    @test reinterpret(UInt32, Gray24()) === 0x00000000
-    @test reinterpret(UInt32, AGray32()) === 0xff000000
-
-    @test reinterpret(UInt32, RGB24(0.071,0.204,0.337)) === 0x00123456
-    @test reinterpret(UInt32, ARGB32(0.071,0.204,0.337,0.671)) === 0xab123456
-    @test reinterpret(UInt32, Gray24(0.071)) === 0x00121212
-    @test reinterpret(UInt32, AGray32(0.071, 0.671)) === 0xab121212
-
-    @test reinterpret(RGB24, 0x00123456) === RGB24(0.071,0.204,0.337)
-    @test reinterpret(RGB24, 0xdc123456) ==  RGB24(0.071,0.204,0.337)
-    @test reinterpret(RGB24, 0x00123456) !== reinterpret(RGB24, 0xdc123456)
-    @test reinterpret(UInt32, reinterpret(RGB24, 0xdc123456)) === 0xdc123456
-
-    @test reinterpret(ARGB32, 0xab123456) === ARGB32(0.071,0.204,0.337,0.671)
-
-    @test reinterpret(Gray24, 0x00121212) === Gray24(0.071)
-    @test reinterpret(Gray24, 0xdc121212) ==  Gray24(0.071)
-    @test reinterpret(Gray24, 0x00121212) !== reinterpret(Gray24, 0xdc121212)
-    @test reinterpret(UInt32, reinterpret(Gray24, 0xdc121212)) === 0xdc121212
-    # the following behavior is undefined, so this is just for the regression test.
-    @test reinterpret(Gray24, 0xdc00ff12) ==  Gray24(0.071)
-    @test reinterpret(UInt32, reinterpret(Gray24, 0xdc00ff12)) === 0xdc00ff12
-
-    @test reinterpret(AGray32, 0xab121212) === AGray32(0.071, 0.671)
-
-    @test_throws MethodError reinterpret(UInt32, ARGB{N0f8}())
-    @test_throws ErrorException reinterpret(ARGB{N0f8}, 0x12345678)
-end
-
 @testset "comparisons" begin
     Cp3 = ColorTypes.parametric3
     for C in unique(vcat(Cp3, coloralpha.(Cp3), alphacolor.(Cp3)))


### PR DESCRIPTION
This fixes #163.

This PR also moves `real` and `reinterpret` to "conversions.jl", and removes the methods which were once needed due to ambiguity.

