### PR TITLE
Fix display of strange element types within `colorant_string_with_eltype`

### DIFF
--- a/src/show.jl
+++ b/src/show.jl
@@ -6,6 +6,8 @@ show_normed(io::IO, c::Gray24) = print(io, "Gray24(", gray(c), ')')
 show_normed(io::IO, c::RGB24)  = print(io, "RGB24(", red(c), ',', green(c), ',', blue(c), ')')
 show_normed(io::IO, c::ARGB32) = print(io, "ARGB32(", red(c), ',', green(c), ',', blue(c), ',', alpha(c), ')')
 
+# FIXME: handle `Color` and `TransparentColor` correctly
+#       (e.g. `Color{T,4}` such as CMYK is different from `Transparent3`).
 for N = 1:4
     component = N >= 3 ? (:comp1, :comp2, :comp3, :alpha) : (:comp1, :alpha)
     printargs = Array{Any}(undef, 2, N)
@@ -45,3 +47,32 @@ function Base.showarg(io::IO, a::Array{C}, toplevel) where C<:Colorant
     print(io, ",$(ndims(a))}")
     toplevel && print(io, " with eltype ", C)
 end
+
+
+colorant_string(::Type{Union{}}) = "Union{}"
+colorant_string(::Type{C}) where {C<:Colorant} = string(nameof(C))
+function colorant_string_with_eltype(::Type{C}) where {C<:Colorant}
+    io = IOBuffer()
+    colorant_string_with_eltype(io, C)
+    String(take!(io))
+end
+colorant_string_with_eltype(io::IO, ::Type{Union{}}) = show(io, Union{})
+function colorant_string_with_eltype(io::IO, ::Type{C}) where {C<:Colorant}
+    if isconcretetype(C)
+        print(io, colorant_string(C))
+        print(io, '{')
+        showcoloranttype(io, eltype(C))
+        print(io, '}')
+    else
+        print(io, C)
+    end
+end
+# Nonparametric types
+colorant_string_with_eltype(io::IO, ::Type{Gray24})  = print(io, "Gray24")
+colorant_string_with_eltype(io::IO, ::Type{AGray32}) = print(io, "AGray32")
+colorant_string_with_eltype(io::IO, ::Type{RGB24})   = print(io, "RGB24")
+colorant_string_with_eltype(io::IO, ::Type{ARGB32})  = print(io, "ARGB32")
+
+showcoloranttype(io, ::Type{Union{}}) = show(io, Union{})
+showcoloranttype(io, ::Type{T}) where {T<:FixedPoint} = FixedPointNumbers.showtype(io, T)
+showcoloranttype(io, ::Type{T}) where {T} = show(io, T)

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -322,29 +322,6 @@ floattype(::Type{ARGB32}) = ARGB{Float32}
 floattype(::Type{AGray32}) = AGray{Float32}
 
 
-colorant_string(::Type{Union{}}) = "Union{}"
-colorant_string(::Type{C}) where {C<:Colorant} = string(nameof(C))
-function colorant_string_with_eltype(::Type{C}) where {C<:Colorant}
-    io = IOBuffer()
-    colorant_string_with_eltype(io, C)
-    String(take!(io))
-end
-colorant_string_with_eltype(io::IO, ::Type{Union{}}) = show(io, Union{})
-function colorant_string_with_eltype(io::IO, ::Type{C}) where {C<:Colorant}
-    print(io, colorant_string(C), '{')
-    showcoloranttype(io, eltype(C))
-    print(io, '}')
-end
-# Nonparametric types
-colorant_string_with_eltype(io::IO, ::Type{Gray24})  = print(io, "Gray24")
-colorant_string_with_eltype(io::IO, ::Type{AGray32}) = print(io, "AGray32")
-colorant_string_with_eltype(io::IO, ::Type{RGB24})   = print(io, "RGB24")
-colorant_string_with_eltype(io::IO, ::Type{ARGB32})  = print(io, "ARGB32")
-
-showcoloranttype(io, ::Type{Union{}}) = show(io, Union{})
-showcoloranttype(io, ::Type{T}) where {T<:FixedPoint} = FixedPointNumbers.showtype(io, T)
-showcoloranttype(io, ::Type{T}) where {T} = show(io, T)
-
 @pure pureintersect(::Type{C1}, ::Type{C2}) where {C1,C2} = typeintersect(C1, C2)
 
 """

--- a/test/show.jl
+++ b/test/show.jl
@@ -52,4 +52,40 @@ end
     @test String(take!(iob)) == "2×2 Array{RGB{Float64},2} with eltype RGB{Float64}"
     summary(iob, view(mat,:,:))
     @test String(take!(iob)) == "2×2 view(::Array{RGB{Float64},2}, :, :) with eltype RGB{Float64}"
+    summary(iob, TransparentColor[ARGB32(), HSVA(30,1,1,0.5)])
+    @test String(take!(iob)) == "2-element Array{TransparentColor,1} with eltype TransparentColor"
+end
+
+@testset "colorant_string" begin
+    @test ColorTypes.colorant_string(Union{}) == "Union{}"
+    @test ColorTypes.colorant_string(RGB{N0f8}) == "RGB"
+    @test ColorTypes.colorant_string(HSV{Float32}) == "HSV"
+    @test ColorTypes.colorant_string(RGB24) == "RGB24"
+    @test ColorTypes.colorant_string(ARGB32) == "ARGB32"
+    @test ColorTypes.colorant_string(Gray24) == "Gray24"
+    @test ColorTypes.colorant_string(AGray32) == "AGray32"
+    @test ColorTypes.colorant_string(RGB) == "RGB"
+    @test_throws MethodError ColorTypes.colorant_string(Float32)
+end
+
+@testset "colorant_string_with_eltype" begin
+    @test ColorTypes.colorant_string_with_eltype(Union{}) == "Union{}"
+    @test ColorTypes.colorant_string_with_eltype(RGB{N0f8}) == "RGB{N0f8}"
+    @test ColorTypes.colorant_string_with_eltype(HSV{Float32}) == "HSV{Float32}"
+    @test ColorTypes.colorant_string_with_eltype(RGB24) == "RGB24"
+    @test ColorTypes.colorant_string_with_eltype(ARGB32) == "ARGB32"
+    @test ColorTypes.colorant_string_with_eltype(Gray24) == "Gray24"
+    @test ColorTypes.colorant_string_with_eltype(AGray32) == "AGray32"
+    @test ColorTypes.colorant_string_with_eltype(RGB) == "RGB"
+    @test ColorTypes.colorant_string_with_eltype(RGB{Union{}}) == "RGB{Union{}}"
+    @test ColorTypes.colorant_string_with_eltype(RGB{<:Fractional}) == "RGB"
+    @test ColorTypes.colorant_string_with_eltype(HSV{<:AbstractFloat}) == "HSV"
+    @test ColorTypes.colorant_string_with_eltype(RGB{Fractional}) == "RGB{Union{AbstractFloat, FixedPoint}}"
+    @test ColorTypes.colorant_string_with_eltype(HSV{AbstractFloat}) == "HSV{AbstractFloat}"
+    @test ColorTypes.colorant_string_with_eltype(TransparentColor) == "TransparentColor"
+    @test ColorTypes.colorant_string_with_eltype(TransparentColor{RGB{Float32},Float32}) ==
+        "TransparentColor{RGB{Float32},Float32,N} where N"
+    @test ColorTypes.colorant_string_with_eltype(TransparentColor{RGB{Float32},Float32,4}) ==
+        "TransparentColor{RGB{Float32},Float32,4}"
+    @test_throws MethodError ColorTypes.colorant_string_with_eltype(Float32)
 end

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -439,33 +439,6 @@ end
     @test_throws MethodError @inferred(floattype(RGB{N0f8}(1,0,0)))
 end
 
-# TODO: move `colorant_string` to `show.jl`
-@testset "colorant_string" begin
-    @test ColorTypes.colorant_string(Union{}) == "Union{}"
-    @test ColorTypes.colorant_string(RGB{N0f8}) == "RGB"
-    @test ColorTypes.colorant_string(HSV{Float32}) == "HSV"
-    @test ColorTypes.colorant_string(RGB24) == "RGB24"
-    @test ColorTypes.colorant_string(ARGB32) == "ARGB32"
-    @test ColorTypes.colorant_string(Gray24) == "Gray24"
-    @test ColorTypes.colorant_string(AGray32) == "AGray32"
-    @test ColorTypes.colorant_string(RGB) == "RGB"
-    @test_throws MethodError ColorTypes.colorant_string(Float32)
-end
-
-# TODO: move `colorant_string_with_eltype` to `show.jl`
-@testset "colorant_string_with_eltype" begin
-    @test ColorTypes.colorant_string_with_eltype(Union{}) == "Union{}"
-    @test ColorTypes.colorant_string_with_eltype(RGB{N0f8}) == "RGB{N0f8}"
-    @test ColorTypes.colorant_string_with_eltype(HSV{Float32}) == "HSV{Float32}"
-    @test ColorTypes.colorant_string_with_eltype(RGB24) == "RGB24"
-    @test ColorTypes.colorant_string_with_eltype(ARGB32) == "ARGB32"
-    @test ColorTypes.colorant_string_with_eltype(Gray24) == "Gray24"
-    @test ColorTypes.colorant_string_with_eltype(AGray32) == "AGray32"
-    @test_broken ColorTypes.colorant_string_with_eltype(RGB) != "RGB{Any}" # TODO: define the appropriate expression
-    @test ColorTypes.colorant_string_with_eltype(RGB{Union{}}) == "RGB{Union{}}"
-    @test_throws MethodError ColorTypes.colorant_string_with_eltype(Float32)
-end
-
 @testset "parametric_colorant" begin
     @test parametric_colorant(RGB{Float32}) === RGB{Float32}
     @test parametric_colorant(RGB)          === RGB
@@ -486,10 +459,10 @@ end
     @test @inferred(ccolor(AbstractRGB, RGB24)) === RGB24
     @test_throws ErrorException ccolor(AbstractRGB{Float32}, RGB24)
 
-    @test @inferred(ccolor(RGB, RGB)) == RGB # with symbol `S` instead of `T`
-    @test @inferred(ccolor(RGB, HSV)) == RGB # with symbol `S` instead of `T`
-    @test @inferred(ccolor(Gray, Gray)) == Gray # with symbol `S` instead of `T`
-    @test @inferred(ccolor(Gray, HSV)) == Gray # with symbol `S` instead of `T`
+    @test @inferred(ccolor(RGB, RGB)) === RGB
+    @test @inferred(ccolor(RGB, HSV)) === RGB
+    @test @inferred(ccolor(Gray, Gray)) === Gray
+    @test @inferred(ccolor(Gray, HSV)) === Gray
 
     @test @inferred(ccolor(RGB{Float32}, HSV{Float32})) === RGB{Float32}
     @test @inferred(ccolor(RGB{N0f8}, HSV{Float32})) === RGB{N0f8}
@@ -516,7 +489,7 @@ end
     @test @inferred(ccolor(Gray, Float32)) === Gray{Float32}
 
     @test @inferred(ccolor(RGB{N0f8}, Bool)) === RGB{N0f8}
-    @test_broken @inferred(ccolor(RGB, Bool)) === RGB{Bool}
+    @test @inferred(ccolor(RGB, Bool)) === RGB{N0f8}
     @test @inferred(ccolor(RGB, Int)) === RGB{N0f8}
     @test @inferred(ccolor(RGB, Float32)) === RGB{Float32}
 


### PR DESCRIPTION
This fixes #151, but does not change `eltype(C)` for the backward compatibility.
This also moves `colorant_string` and `colorant_string_with_eltype` to "show.jl".