### PR TITLE
updates to ones, zeros, oneunit and zero to keep consistency to Base

### DIFF
--- a/src/traits.jl
+++ b/src/traits.jl
@@ -514,7 +514,9 @@ isapprox(x::AbstractGray, y::Number; kwargs...) =
 
 
 zero(::Type{C}) where {C<:Gray} = C(0)
+zero(::C) where {C<:Gray} = C(0)
 oneunit(::Type{C}) where {C<:Gray} = C(1)
+oneunit(::C) where {C<:Gray} = C(1)
 
 function Base.one(::Type{C}) where {C<:Gray}
     Base.depwarn("one($C) will soon switch to returning 1; you might need to switch to `oneunit`", :one)

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -522,6 +522,7 @@ function Base.one(::Type{C}) where {C<:Gray}
     Base.depwarn("one($C) will soon switch to returning 1; you might need to switch to `oneunit`", :one)
     C(1)
 end
+Base.one(::C) where {C<:Gray} = one(C)
 
 Base.broadcastable(x::Colorant) = Ref(x)
 

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -523,5 +523,10 @@ end
 
 Base.broadcastable(x::Colorant) = Ref(x)
 
+# with one(C) deprecated, we need to override the default function call to use oneunit instead of one
+Base.ones(::Type{C}, dims::Tuple{}) where {C<:Gray, N} = fill(oneunit(C))
+Base.ones(::Type{C}, dims::Tuple{Vararg{Integer, N}}) where {C<:Gray, N} = fill(oneunit(C), dims)
+Base.ones(::Type{C}, dims::Union{Integer, AbstractUnitRange}...) where {C<:Gray} = fill(oneunit(C), dims...)
+
 Base.isless(a::AbstractGray, b::AbstractGray) =
     isless(gray(a), gray(b))

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -678,13 +678,33 @@ end
     @test oneunit(Gray) === Gray{N0f8}(1)
     @test zero(Gray) === Gray{N0f8}(0)
 
-    for T in (N0f8, Float32)
+    @test ones(Gray) == fill(oneunit(Gray))
+    @test ones(Gray, 4, 4) == fill(oneunit(Gray), 4, 4) == Gray.(ones(N0f8, 4, 4))
+    @test eltype(ones(Gray, 4, 4)) == Gray{N0f8}
+
+    @test zeros(Gray) == fill(zero(Gray))
+    @test zeros(Gray, 4, 4) == fill(zero(Gray), 4, 4) == Gray.(zeros(N0f8, 4, 4))
+    @test eltype(zeros(Gray, 4, 4)) == Gray{N0f8}
+
+    for T in (Bool, N0f8, Float32)
+        for (fname, felt) in ((:zeros, :zero), (:ones, :oneunit))
+            @eval begin
+                @test $fname(Gray{$T}) == fill($felt(Gray{$T}))
+                A = $fname(Gray{$T}, 4, 4)
+                @test A == $fname(Gray{$T}, (4, 4))
+                @test A == $fname(Gray{$T}, Base.OneTo(4), Base.OneTo(4))
+                @test A == $fname(Gray{$T}, (Base.OneTo(4), Base.OneTo(4)))
+                @test eltype(A) == Gray{$T}
+            end
+        end
+
         @test oneunit(Gray{T}) === Gray{T}(1)
         @test zero(Gray{T}) === Gray{T}(0)
 
-        @test ones(Gray{T}) == fill(oneunit(Gray{T}))
-        @test ones(Gray{T}, 4, 4) == ones(Gray{T}, (4, 4)) == Gray.(ones(T, 4, 4))
-        @test eltype(ones(Gray{T}, 4, 4)) == Gray{T}
+        T === Bool && continue
+        g = Gray{T}(0.8)
+        @test oneunit(g) == oneunit(T) == Gray(oneunit(T))
+        @test zero(g) == zero(T) == Gray(zero(T))
     end
 
     @test_throws MethodError oneunit(Gray24)
@@ -698,12 +718,4 @@ end
 
     @test_throws MethodError oneunit(RGB{N0f8})
     @test_throws MethodError zero(RGB{N0f8})
-
-    for T in (N0f8, Float32)
-        g = Gray{T}(0.8)
-        @test oneunit(g) == oneunit(T) == Gray(oneunit(T))
-        @test zero(g) == zero(T) == Gray(zero(T))
-    end
-
-    @test_broken one(Gray{Float32}) * g == g * one(Gray{Float32}) == g
 end

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -699,9 +699,11 @@ end
     @test_throws MethodError oneunit(RGB{N0f8})
     @test_throws MethodError zero(RGB{N0f8})
 
-    g = Gray{Float32}(0.8)
-    @test_throws MethodError oneunit(g)
-    @test_throws MethodError zero(g)
+    for T in (N0f8, Float32)
+        g = Gray{T}(0.8)
+        @test oneunit(g) == oneunit(T) == Gray(oneunit(T))
+        @test zero(g) == zero(T) == Gray(zero(T))
+    end
 
     @test_broken one(Gray{Float32}) * g == g * one(Gray{Float32}) == g
 end

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -707,6 +707,11 @@ end
         @test zero(g) == zero(T) == Gray(zero(T))
     end
 
+    # TODO: strip Gray wrapper when `one(Gray)` switches to return 1
+    @test one(Gray) === Gray{N0f8}(1)
+    @test one(Gray{Float32}) === Gray{Float32}(1)
+    @test one(Gray{N0f8}(0.8)) === Gray{N0f8}(1)
+
     @test_throws MethodError oneunit(Gray24)
     @test_throws MethodError zero(Gray24)
     @test_throws MethodError oneunit(AGray32)

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -675,10 +675,17 @@ end
 end
 
 @testset "identities for Gray" begin
-    @test oneunit(Gray{N0f8}) === Gray{N0f8}(1)
-    @test zero(Gray{N0f8}) === Gray{N0f8}(0)
     @test oneunit(Gray) === Gray{N0f8}(1)
     @test zero(Gray) === Gray{N0f8}(0)
+
+    for T in (N0f8, Float32)
+        @test oneunit(Gray{T}) === Gray{T}(1)
+        @test zero(Gray{T}) === Gray{T}(0)
+
+        @test ones(Gray{T}) == fill(oneunit(Gray{T}))
+        @test ones(Gray{T}, 4, 4) == ones(Gray{T}, (4, 4)) == Gray.(ones(T, 4, 4))
+        @test eltype(ones(Gray{T}, 4, 4)) == Gray{T}
+    end
 
     @test_throws MethodError oneunit(Gray24)
     @test_throws MethodError zero(Gray24)


### PR DESCRIPTION
* make usage like `ones(Gray{N0f8}, 4, 4)` doesn't throw depwarns (closes #137)
* (RFC) make `oneunit(::Gray)` and `zero(::Gray)` valid and keep consistency to Base behavior
* `eltype(zeros(Gray)) == typeof(zero(Gray)) == Gray{N0f8}` (closes https://github.com/JuliaGraphics/Colors.jl/issues/369)

There must be some discussion on these in julialang/julia but I can't find a source...