### PR TITLE
Support alpha(::Number) and ensure alpha/gray return compatible types

### DIFF
--- a/src/traits.jl
+++ b/src/traits.jl
@@ -7,33 +7,33 @@ without an alpha channel, it will always return 1.
 alpha(c::TransparentColor) = c.alpha
 alpha(c::Color)   = oneunit(eltype(c))
 alpha(c::RGB24)   = N0f8(1)
-alpha(c::ARGB32)  = N0f8((c.color & 0xff000000)>>24, 0)
-alpha(c::AGray32) = N0f8((c.color & 0xff000000)>>24, 0)
+alpha(c::ARGB32)  = reinterpret(N0f8, (c.color >> 0x18) % UInt8)
+alpha(c::AGray32) = reinterpret(N0f8, (c.color >> 0x18) % UInt8)
 alpha(x::Number)  = convert(eltype(ccolor(Gray, typeof(x))), oneunit(x))  # ensures it's a type supported by Gray (which has widest eltype support)
 
 "`red(c)` returns the red component of an `AbstractRGB` opaque or transparent color."
 red(c::AbstractRGB   ) = c.r
 red(c::TransparentRGB) = c.r
-red(c::RGB24)  = N0f8((c.color & 0x00ff0000)>>16, 0)
-red(c::ARGB32) = N0f8((c.color & 0x00ff0000)>>16, 0)
+red(c::RGB24)  = reinterpret(N0f8, (c.color >> 0x10) % UInt8)
+red(c::ARGB32) = reinterpret(N0f8, (c.color >> 0x10) % UInt8)
 
 "`green(c)` returns the green component of an `AbstractRGB` opaque or transparent color."
 green(c::AbstractRGB   ) = c.g
 green(c::TransparentRGB) = c.g
-green(c::RGB24)  = N0f8((c.color & 0x0000ff00)>>8, 0)
-green(c::ARGB32) = N0f8((c.color & 0x0000ff00)>>8, 0)
+green(c::RGB24)  = reinterpret(N0f8, (c.color >> 0x08) % UInt8)
+green(c::ARGB32) = reinterpret(N0f8, (c.color >> 0x08) % UInt8)
 
 "`blue(c)` returns the blue component of an `AbstractRGB` opaque or transparent color."
 blue(c::AbstractRGB   ) = c.b
 blue(c::TransparentRGB) = c.b
-blue(c::RGB24)  = N0f8(c.color & 0x000000ff, 0)
-blue(c::ARGB32) = N0f8(c.color & 0x000000ff, 0)
+blue(c::RGB24)  = reinterpret(N0f8, c.color % UInt8)
+blue(c::ARGB32) = reinterpret(N0f8, c.color % UInt8)
 
 "`gray(c)` returns the gray component of a grayscale opaque or transparent color."
 gray(c::Gray)    = c.val
 gray(c::TransparentGray) = c.val
-gray(c::Gray24)  = N0f8(c.color & 0x000000ff, 0)
-gray(c::AGray32) = N0f8(c.color & 0x000000ff, 0)
+gray(c::Gray24)  = reinterpret(N0f8, c.color % UInt8)
+gray(c::AGray32) = reinterpret(N0f8, c.color % UInt8)
 gray(x::Number)  = convert(eltype(ccolor(Gray, typeof(x))), x)   # ensures it's a type supported by Gray
 
 """

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -9,6 +9,7 @@ alpha(c::Color)   = oneunit(eltype(c))
 alpha(c::RGB24)   = N0f8(1)
 alpha(c::ARGB32)  = N0f8((c.color & 0xff000000)>>24, 0)
 alpha(c::AGray32) = N0f8((c.color & 0xff000000)>>24, 0)
+alpha(x::Number)  = convert(eltype(ccolor(Gray, typeof(x))), oneunit(x))  # ensures it's a type supported by Gray (which has widest eltype support)
 
 "`red(c)` returns the red component of an `AbstractRGB` opaque or transparent color."
 red(c::AbstractRGB   ) = c.r
@@ -33,7 +34,7 @@ gray(c::Gray)    = c.val
 gray(c::TransparentGray) = c.val
 gray(c::Gray24)  = N0f8(c.color & 0x000000ff, 0)
 gray(c::AGray32) = N0f8(c.color & 0x000000ff, 0)
-gray(x::Number)  = x
+gray(x::Number)  = convert(eltype(ccolor(Gray, typeof(x))), x)   # ensures it's a type supported by Gray
 
 """
 `chroma(c)` returns the chroma of a `Lab`, `Luv` or their variants color.

--- a/src/types.jl
+++ b/src/types.jl
@@ -519,7 +519,7 @@ macro make_alpha(C, acol, cola, fields, constrfields, ub, elty)
             $acol{T}(p...)
         end
         function $acol($(constrfields...), alpha::Real)
-            p = promote($(constrfields...), alpha)
+            p = promote($(constrfields...), gray(alpha))
             T = typeof(p[1])
             $acol{T}(p...)
         end
@@ -536,7 +536,7 @@ macro make_alpha(C, acol, cola, fields, constrfields, ub, elty)
             $cola{T}(p...)
         end
         function $cola($(constrfields...), alpha::Real)
-            p = promote($(constrfields...), alpha)
+            p = promote($(constrfields...), gray(alpha))
             T = typeof(p[1])
             $cola{T}(p...)
         end
@@ -544,7 +544,7 @@ macro make_alpha(C, acol, cola, fields, constrfields, ub, elty)
         $cola() = $cola{$elty}($(zfields...))
         $cola($convqualifier) = convert($cola, x)
         $cola{T}(x) where T = convert($cola{T}, x)
-end)
+    end)
 end
 
 eltype_default(::Type{C}) where {C<:AbstractRGB  } = N0f8

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -585,8 +585,8 @@ end
 
     @test convert(RGB, 0.6) === RGB(0.6, 0.6, 0.6)
     @test convert(BGR, 0.6N0f8) === BGR{N0f8}(0.6, 0.6, 0.6)
-    @test_broken convert(ARGB, 0.6) === ARGB(0.6, 0.6, 0.6, 1)
-    @test_broken convert(RGBA, 0.6N0f8) === RGBA{N0f8}(0.6, 0.6, 0.6, 1)
+    @test convert(ARGB, 0.6) === ARGB(0.6, 0.6, 0.6, 1)
+    @test convert(RGBA, 0.6N0f8) === RGBA{N0f8}(0.6, 0.6, 0.6, 1)
 
     @test_broken convert(ARGB, 0.6f0, 0.8f0) === ARGB{Float32}(0.6, 0.6, 0.6, 0.8)
     @test_broken convert(RGBA{Float32}, 0.6, 0.8) === RGBA{Float32}(0.6, 0.6, 0.6, 0.8)

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -62,8 +62,8 @@ end
     @test alpha(HSV{Float16}(100, 0.4, 0.6)) === Float16(1.0)
     @test alpha(HSVA(100, 0.4, 0.6, 0.8)) === 0.8
     @test alpha(AHSV{Float32}(100, 0.4, 0.6, 0.8)) === 0.8f0
-    @test_broken alpha(0) === N0f8(1)
-    @test_broken alpha(0.0f0) === 1.0f0
+    @test alpha(0)     === N0f8(1)
+    @test alpha(0.0f0) === 1.0f0
 end
 
 @testset "gray" begin
@@ -76,11 +76,12 @@ end
     @test gray(Gray{Bool}(0)) === false
 
     @testset "gray for Real" begin
-        @test gray(1) === 1 # TODO: change it to return `N0f8(1)`
-        @test gray(0.8) === 0.8
+        @test gray(1)       === N0f8(1)
+        @test gray(0.8)     === 0.8
         @test gray(0.8N0f8) === 0.8N0f8
-        @test gray(true) === true
-        @test gray(false) === false
+        @test gray(true)    === true
+        @test gray(false)   === false
+        @test gray(1//2)    === 1/2   # depends on https://github.com/JuliaMath/FixedPointNumbers.jl/pull/177
     end
     @test_throws MethodError gray(HSVA(100, 0.4, 0.6, 0.8))
     @test_throws MethodError gray(Cyanotype{Float32}(0.8)) # 1-component color but not a gray

--- a/test/types.jl
+++ b/test/types.jl
@@ -266,14 +266,8 @@ end
         @test GrayA{N0f16}(val) === GrayA{N0f16}(0.2, 1)
         @test AGray32(val) === AGray32(0.2, 1)
         @test AGray32(val, 0.8) === AGray32(0.2, 0.8)
-        if val isa FixedPoint
-            @test AGray(val, 1) === AGray{Float32}(0.2, 1) # inconsistent eltype
-            @test_broken @inferred(AGray(val, 1)) === AGray{T}(0.2, 1)
-            @test_broken @inferred(GrayA(val, 0)) === GrayA{T}(0.2, 0)
-        else
-            @test @inferred(AGray(val, 1)) === AGray{T}(0.2, 1)
-            @test @inferred(GrayA(val, 0)) === GrayA{T}(0.2, 0)
-        end
+        @test @inferred(AGray(val, 1)) === AGray{T}(0.2, 1)
+        @test @inferred(GrayA(val, 0)) === GrayA{T}(0.2, 0)
         Ta = val isa AbstractGray ? T : Float64
         if val isa Gray24
             @test_broken @inferred(AGray(val, 0.8)) === AGray{Ta}(val, 0.8)

--- a/test/types.jl
+++ b/test/types.jl
@@ -145,8 +145,8 @@ end
                 @test C{N0f16}(val1,val2,val1,0.8) === C(0.2N0f16,0.6N0f16,0.2N0f16,0.8N0f16)
             end
             # 1-arg constructor
-            @test_broken C(val1) === C{typeof(val1)}(0.2,0.2,0.2,1)
-            @test_broken C{N0f8}(val1) === C{N0f8}(0.2,0.2,0.2,1)
+            @test C(val1) === C{typeof(val1)}(0.2,0.2,0.2,1)
+            @test C{N0f8}(val1) === C{N0f8}(0.2,0.2,0.2,1)
         end
 
         @test_throws ArgumentError C(2,1,0) # integers
@@ -161,6 +161,7 @@ end
             @test isa(C(val,val,val), C)
             @test isa(C(val,val,val,0.8), C)
             @test isa(C(val,val,val,val), C) # no exception thrown
+            @test alpha(C(val)) === oneunit(val)
         end
     end
 end


### PR DESCRIPTION
Closes #162. I decided to continue to support any `::Number` as long as it can be `convert`ed to a supported type. Consequently
```julia
julia> using FixedPointNumbers, ColorTypes

julia> FixedPointNumbers.floattype(::Type{Complex{T}}) where T = Complex{floattype(T)}

julia> gray(1+0im)
1.0N0f8

julia> gray(1+1im)
ERROR: InexactError: Int64(1 + 1im)
Stacktrace:
 [1] Real at ./complex.jl:37 [inlined]
 [2] convert at ./number.jl:7 [inlined]
 [3] FixedPoint at /home/tim/.julia/packages/FixedPointNumbers/w2pxG/src/FixedPointNumbers.jl:56 [inlined]
 [4] convert at ./number.jl:7 [inlined]
 [5] gray(::Complex{Int64}) at /home/tim/.julia/dev/ColorTypes/src/traits.jl:37
 [6] top-level scope at REPL[5]:1
```
(Not sure if that is worth adding to the tests.) This is consistent with the general philosophy that types are about dispatch and algorithmic efficiency, but that functionality should depend primarily on value.

Breaking change: yes (conversions that can't be performed will now error, and some return values will be of different types).