### PR TITLE
add custom error hints for zero and one to ColorVectorSpace

### DIFF
--- a/src/ColorTypes.jl
+++ b/src/ColorTypes.jl
@@ -85,4 +85,8 @@ if VERSION >= v"1.1" # work around https://github.com/JuliaLang/julia/issues/341
     _precompile_()
 end
 
+function __init__()
+    include(joinpath(@__DIR__, "error_hints.jl"))
+end
+
 end # module

--- a/src/error_hints.jl
+++ b/src/error_hints.jl
@@ -1,0 +1,11 @@
+# provided by https://github.com/JuliaLang/julia/pull/35094
+if VERSION >= v"1.5.0-DEV.491"
+    register_error_hint(MethodError) do io, exc, argtypes, kwargs
+        if exc.f in (zero, one) && argtypes[1] <: Union{Type{<:AbstractRGB}, AbstractRGB}
+            print(io, "\ndid you forget to `using ColorVectorSpace`?")
+        end
+        if exc.f in (zeros, ones) && argtypes[1] <: Type{<:AbstractRGB} 
+            print(io, "\ndid you forget to `using ColorVectorSpace`?")
+        end
+    end
+end

--- a/src/error_hints.jl
+++ b/src/error_hints.jl
@@ -2,10 +2,10 @@
 if VERSION >= v"1.5.0-DEV.491"
     register_error_hint(MethodError) do io, exc, argtypes, kwargs
         if exc.f in (zero, one) && argtypes[1] <: Union{Type{<:AbstractRGB}, AbstractRGB}
-            print(io, "\ndid you forget to `using ColorVectorSpace`?")
+            print(io, "\nYou may need to `using ColorVectorSpace`.")
         end
         if exc.f in (zeros, ones) && argtypes[1] <: Type{<:AbstractRGB} 
-            print(io, "\ndid you forget to `using ColorVectorSpace`?")
+            print(io, "\nYou may need to `using ColorVectorSpace`.")
         end
     end
 end

--- a/test/error_hints.jl
+++ b/test/error_hints.jl
@@ -19,27 +19,27 @@ end
         for T in (RGB, RGB{N0f8})
             err_str = @except_str zero(T) MethodError
             @test occursin(r"MethodError: no method matching zero\(::Type\{RGB.*\}", err_str)
-            @test occursin("did you forget to `using ColorVectorSpace`?", err_str)
+            @test occursin("You may need to `using ColorVectorSpace`.", err_str)
 
             err_str = @except_str zero(T(1, 1, 1)) MethodError
             @test occursin(r"MethodError: no method matching zero\(::RGB\{.*\}", err_str)
-            @test occursin("did you forget to `using ColorVectorSpace`?", err_str)
+            @test occursin("You may need to `using ColorVectorSpace`.", err_str)
 
             err_str = @except_str zeros(T) MethodError
             @test occursin(r"MethodError: no method matching zero\(::Type\{RGB.*\}", err_str)
-            @test occursin("did you forget to `using ColorVectorSpace`?", err_str)
+            @test occursin("You may need to `using ColorVectorSpace`.", err_str)
 
             err_str = @except_str one(T) MethodError
             @test occursin(r"MethodError: no method matching one\(::Type\{RGB.*\}", err_str)
-            @test occursin("did you forget to `using ColorVectorSpace`?", err_str)
+            @test occursin("You may need to `using ColorVectorSpace`.", err_str)
 
             err_str = @except_str one(T(1, 1, 1)) MethodError
             @test occursin(r"MethodError: no method matching one\(::RGB\{.*\}", err_str)
-            @test occursin("did you forget to `using ColorVectorSpace`?", err_str)
+            @test occursin("You may need to `using ColorVectorSpace`.", err_str)
 
             err_str = @except_str ones(T) MethodError
             @test occursin(r"MethodError: no method matching one\(::Type\{RGB.*\}", err_str)
-            @test occursin("did you forget to `using ColorVectorSpace`?", err_str)
+            @test occursin("You may need to `using ColorVectorSpace`.", err_str)
         end
     end
 end

--- a/test/error_hints.jl
+++ b/test/error_hints.jl
@@ -1,0 +1,45 @@
+macro except_str(expr, err_type)
+    return quote
+        let err = nothing
+            try
+                $(esc(expr))
+            catch err
+            end
+            err === nothing && error("expected failure, but no exception thrown")
+            @test typeof(err) === $(esc(err_type))
+            buf = IOBuffer()
+            showerror(buf, err)
+            String(take!(buf))
+        end
+    end
+end
+
+@testset "error hints" begin
+    @testset "zeros/ones" begin
+        for T in (RGB, RGB{N0f8})
+            err_str = @except_str zero(T) MethodError
+            @test occursin(r"MethodError: no method matching zero\(::Type\{RGB.*\}", err_str)
+            @test occursin("did you forget to `using ColorVectorSpace`?", err_str)
+
+            err_str = @except_str zero(T(1, 1, 1)) MethodError
+            @test occursin(r"MethodError: no method matching zero\(::RGB\{.*\}", err_str)
+            @test occursin("did you forget to `using ColorVectorSpace`?", err_str)
+
+            err_str = @except_str zeros(T) MethodError
+            @test occursin(r"MethodError: no method matching zero\(::Type\{RGB.*\}", err_str)
+            @test occursin("did you forget to `using ColorVectorSpace`?", err_str)
+
+            err_str = @except_str one(T) MethodError
+            @test occursin(r"MethodError: no method matching one\(::Type\{RGB.*\}", err_str)
+            @test occursin("did you forget to `using ColorVectorSpace`?", err_str)
+
+            err_str = @except_str one(T(1, 1, 1)) MethodError
+            @test occursin(r"MethodError: no method matching one\(::RGB\{.*\}", err_str)
+            @test occursin("did you forget to `using ColorVectorSpace`?", err_str)
+
+            err_str = @except_str ones(T) MethodError
+            @test occursin(r"MethodError: no method matching one\(::Type\{RGB.*\}", err_str)
+            @test occursin("did you forget to `using ColorVectorSpace`?", err_str)
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,13 @@ using Test
     Set([DIN99d, DIN99o, DIN99, HSI, HSL, HSV, LCHab, LCHuv,
          LMS, Lab, Luv, XYZ, YCbCr, YIQ, xyY, BGR, RGB, Gray])
 
+if VERSION >= v"1.5.0-DEV.491"
+    @testset "error_hints" begin
+        # ColorVectorSpace, if needed, should not be imported before this
+        include("error_hints.jl")
+    end
+end
+
 @testset "conversions" begin
     include("conversions.jl")
 end


### PR DESCRIPTION
This gives a user-friendly error message when ColorVectorSpace isn't loaded.

```julia
julia> zero(RGB)
ERROR: MethodError: no method matching zero(::Type{RGB})
did you forget to `using ColorVectorSpace`?
Closest candidates are:
...

julia> zero(RGB(1, 1, 1))
ERROR: MethodError: no method matching zero(::RGB{FixedPointNumbers.Normed{UInt8,8}})
did you forget to `using ColorVectorSpace`?
Closest candidates are:
...
```