### PR TITLE
Add setup block to doctests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - osx
 julia:
   - 1.0
-  - 1.3
+  - 1
   - nightly
 notifications:
   email: false

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -282,7 +282,7 @@ Return a parametric colorant type.
 
 # Examples
 
-```jldoctest; setup = :(using ColorTypes, FixedPointNumbers)
+```jldoctest; setup = :(using ColorTypes, ColorTypes.FixedPointNumbers)
 julia> parametric_colorant(RGB)
 RGB
 
@@ -347,7 +347,7 @@ end
 numeric element type. `ccolor` chooses the numeric element type from
 `Cdest` if available, but if not specified gets it from `Csrc`.
 
-```jldoctest; setup = :(using ColorTypes, FixedPointNumbers)
+```jldoctest; setup = :(using ColorTypes, ColorTypes.FixedPointNumbers)
 julia> ccolor(RGB, Gray{Float32})
 RGB{Float32}
 
@@ -361,7 +361,7 @@ RGB{Float32}
 Some colorspaces don't support `FixedPoint` numeric element types;
 in such cases the `eltype_default` for `Cdest` is chosen:
 
-```jldoctest; setup = :(using ColorTypes, FixedPointNumbers)
+```jldoctest; setup = :(using ColorTypes, ColorTypes.FixedPointNumbers)
 julia> ccolor(HSV, RGB{N0f8})
 HSV{Float32}
 ```
@@ -369,7 +369,7 @@ HSV{Float32}
 `Cdest` can be an abstract type, in which case `Csrc` must be in that
 abstract color space.
 
-```jldoctest; setup = :(using ColorTypes, FixedPointNumbers)
+```jldoctest; setup = :(using ColorTypes, ColorTypes.FixedPointNumbers)
 julia> ccolor(Color{Float32}, RGB{N0f8})
 RGB{Float32}
 

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -257,7 +257,7 @@ that `Cbase{T}` can be used to specify a colorant with element type `T`.
 However, `base_colorant_type` is not guaranteed to return a parametric result,
 for example
 
-```jldoctest
+```jldoctest; setup = :(using ColorTypes)
 julia> base_colorant_type(RGB24)
 RGB24
 ```
@@ -282,7 +282,7 @@ Return a parametric colorant type.
 
 # Examples
 
-```jldoctest
+```jldoctest; setup = :(using ColorTypes, FixedPointNumbers)
 julia> parametric_colorant(RGB)
 RGB
 
@@ -347,7 +347,7 @@ end
 numeric element type. `ccolor` chooses the numeric element type from
 `Cdest` if available, but if not specified gets it from `Csrc`.
 
-```jldoctest
+```jldoctest; setup = :(using ColorTypes, FixedPointNumbers)
 julia> ccolor(RGB, Gray{Float32})
 RGB{Float32}
 
@@ -361,7 +361,7 @@ RGB{Float32}
 Some colorspaces don't support `FixedPoint` numeric element types;
 in such cases the `eltype_default` for `Cdest` is chosen:
 
-```jldoctest
+```jldoctest; setup = :(using ColorTypes, FixedPointNumbers)
 julia> ccolor(HSV, RGB{N0f8})
 HSV{Float32}
 ```
@@ -369,7 +369,7 @@ HSV{Float32}
 `Cdest` can be an abstract type, in which case `Csrc` must be in that
 abstract color space.
 
-```jldoctest
+```jldoctest; setup = :(using ColorTypes, FixedPointNumbers)
 julia> ccolor(Color{Float32}, RGB{N0f8})
 RGB{Float32}
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -1,4 +1,5 @@
-using ColorTypes, FixedPointNumbers
+using ColorTypes
+using ColorTypes.FixedPointNumbers
 using Test
 using ColorTypes: ColorTypeResolutionError
 

--- a/test/operations.jl
+++ b/test/operations.jl
@@ -1,4 +1,5 @@
-using ColorTypes, FixedPointNumbers
+using ColorTypes
+using ColorTypes.FixedPointNumbers
 using Test
 
 @testset "rand" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,6 @@ using Test
 @test isempty(detect_ambiguities(ColorTypes, Base, Core))
 
 using Documenter
-DocMeta.setdocmeta!(ColorTypes, :DocTestSetup, :(using ColorTypes, FixedPointNumbers); recursive=true)
 doctest(ColorTypes, manual = false)
 
 # if the test below fails, please extend the list of types at the call to

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
-using ColorTypes, FixedPointNumbers
+using ColorTypes
+using ColorTypes.FixedPointNumbers
 using Test
 
 @test isempty(detect_ambiguities(ColorTypes, Base, Core))

--- a/test/show.jl
+++ b/test/show.jl
@@ -1,4 +1,5 @@
-using ColorTypes, FixedPointNumbers
+using ColorTypes
+using ColorTypes.FixedPointNumbers
 using Test
 
 @testset "single color" begin

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -1,4 +1,5 @@
-using ColorTypes, FixedPointNumbers
+using ColorTypes
+using ColorTypes.FixedPointNumbers
 using Test
 using ColorTypes: ColorTypeResolutionError
 

--- a/test/types.jl
+++ b/test/types.jl
@@ -1,4 +1,5 @@
-using ColorTypes, FixedPointNumbers
+using ColorTypes
+using ColorTypes.FixedPointNumbers
 using Test
 
 


### PR DESCRIPTION
This makes them standalone, which is necessary for juliaimages docs. Alternatively we could use the same `setdocmeta!` statement there, but this seems to have lower overhead for any other package that might want to incorporate these docs.