### PR TITLE
fixes a precompilation error when registering error hints

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ColorTypes"
 uuid = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
-version = "0.10.1"
+version = "0.10.2"
 
 [deps]
 FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"

--- a/src/ColorTypes.jl
+++ b/src/ColorTypes.jl
@@ -45,6 +45,7 @@ include("traits.jl")
 include("conversions.jl")
 include("show.jl")
 include("operations.jl")
+include("error_hints.jl")
 
 Base.@deprecate_binding RGB1 XRGB
 Base.@deprecate_binding RGB4 RGBX
@@ -85,8 +86,6 @@ if VERSION >= v"1.1" # work around https://github.com/JuliaLang/julia/issues/341
     _precompile_()
 end
 
-function __init__()
-    include(joinpath(@__DIR__, "error_hints.jl"))
-end
+__init__() = register_hints()
 
 end # module

--- a/src/error_hints.jl
+++ b/src/error_hints.jl
@@ -1,11 +1,13 @@
 # provided by https://github.com/JuliaLang/julia/pull/35094
-if VERSION >= v"1.5.0-DEV.491"
-    register_error_hint(MethodError) do io, exc, argtypes, kwargs
-        if exc.f in (zero, one) && argtypes[1] <: Union{Type{<:AbstractRGB}, AbstractRGB}
-            print(io, "\nYou may need to `using ColorVectorSpace`.")
-        end
-        if exc.f in (zeros, ones) && argtypes[1] <: Type{<:AbstractRGB} 
-            print(io, "\nYou may need to `using ColorVectorSpace`.")
+function register_hints()
+    if VERSION >= v"1.5.0-DEV.491"
+        register_error_hint(MethodError) do io, exc, argtypes, kwargs
+            if exc.f in (zero, one) && argtypes[1] <: Union{Type{<:AbstractRGB}, AbstractRGB}
+                print(io, "\nYou may need to `using ColorVectorSpace`.")
+            end
+            if exc.f in (zeros, ones) && argtypes[1] <: Type{<:AbstractRGB}
+                print(io, "\nYou may need to `using ColorVectorSpace`.")
+            end
         end
     end
 end


### PR DESCRIPTION
#178 is buggy (see https://github.com/JuliaGraphics/ColorTypes.jl/pull/178#issuecomment-614902798), this PR fixes that

Bump a version because it already breaks CI for downstream packages, e.g., https://github.com/JuliaGraphics/ColorSchemes.jl/pull/33, https://github.com/JuliaImages/Images.jl/runs/593248480

~To make sure this kind of issue doesn't happen again, I also added Colors and ImageCore tests in CI.~