### PR TITLE
Fix `show` for colors with uncommon components and `AGray32`

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,8 +397,8 @@ greater detail); just type `?ccolor` at the REPL.
 - `alpha` extracts the alpha channel from any `Color` object
   (returning 1 if there is no alpha channel)
 
-- `comp1`, `comp2`, and `comp3` extract color components in the order
-  expected by the constructor
+- `comp1`, `comp2`, `comp3`, `comp4` and `comp5` extract color components in the
+  order expected by the constructor
 
 ### Functions
 

--- a/src/ColorTypes.jl
+++ b/src/ColorTypes.jl
@@ -37,7 +37,7 @@ export base_color_type, base_colorant_type, ccolor, color, color_type, parametri
 export alphacolor, coloralpha
 export alpha, red, green, blue, gray   # accessor functions that generalize to RGB24, etc.
 export chroma, hue
-export comp1, comp2, comp3
+export comp1, comp2, comp3, comp4, comp5
 export mapc, reducec, mapreducec, gamutmax, gamutmin
 
 include("types.jl")

--- a/src/show.jl
+++ b/src/show.jl
@@ -1,49 +1,32 @@
-show(io::IO, c::Colorant) = get(io, :compact, false) ? _showcompact(io, c) : _show(io, c)
-show(io::IO, c::ColorantNormed) = show_normed(io, c)
 
-# Nonparametric types
-show_normed(io::IO, c::Gray24) = print(io, "Gray24(", gray(c), ')')
-show_normed(io::IO, c::RGB24)  = print(io, "RGB24(", red(c), ',', green(c), ',', blue(c), ')')
-show_normed(io::IO, c::ARGB32) = print(io, "ARGB32(", red(c), ',', green(c), ',', blue(c), ',', alpha(c), ')')
+function show(io::IO, c::Colorant)
+    show_colorant_string_with_eltype(io, typeof(c))
+    _show_components(io, c)
+end
 
-# FIXME: handle `Color` and `TransparentColor` correctly
-#       (e.g. `Color{T,4}` such as CMYK is different from `Transparent3`).
-for N = 1:4
-    component = N >= 3 ? (:comp1, :comp2, :comp3, :alpha) : (:comp1, :alpha)
-    printargs = Array{Any}(undef, 2, N)
+# Special handling for Normed types: don't print the giant type name
+function show(io::IO, c::ColorantNormed)
+    show_colorant_string_with_eltype(io, typeof(c))
+    if isempty(typeof(c).parameters) # Nonparametric types
+        _show_components(io, c) # with trailing "N0f8" unless :compat=>true
+    else
+        _show_components(IOContext(io, :compact=>true), c)
+    end
+end
+
+function _show_components(io::IO, c::ColorantN{N}) where N
+    comp_n = (comp1, comp2, comp3, comp4, comp5)
+    print(io, '(')
     for i = 1:N
-        printargs[1,i] = :(show(io, $(component[i])(c)))
-        chr = i < N ? ',' : ')'
-        printargs[2,i] = :(print(io, $chr))
-    end
-    @eval begin
-        function _show(io::IO, c::Colorant{T,$N}) where T
-            print(io, colorant_string(typeof(c)), "{", T, "}(")
-            $(printargs[:]...)
-        end
-    end
-    for i = 1:N
-        printargs[1,i] = :(show(IOContext(io, :compact => true), $(component[i])(c)))
-    end
-    @eval begin
-        function _showcompact(io::IO, c::Colorant{T,$N}) where T
-            print(io, colorant_string(typeof(c)), "{", T, "}(")
-            $(printargs[:]...)
-        end
-        # Special handling for Normed types: don't print the giant type name
-        function show_normed(io::IO, c::Colorant{FixedPointNumbers.Normed{T,f},$N}) where {T,f}
-            print(io, colorant_string(typeof(c)), '{')
-            FixedPointNumbers.showtype(io, eltype(typeof(c)))
-            print(io, "}(")
-            $(printargs[:]...)
-        end
+        show(io, (comp_n[i])(c))
+        print(io, i < N ? ',' : ')') # without spaces
     end
 end
 
 function Base.showarg(io::IO, a::Array{C}, toplevel) where C<:Colorant
     toplevel || print(io, "::")
     print(io, "Array{")
-    colorant_string_with_eltype(io, C)
+    show_colorant_string_with_eltype(io, C)
     print(io, ",$(ndims(a))}")
     toplevel && print(io, " with eltype ", C)
 end
@@ -53,25 +36,21 @@ colorant_string(::Type{Union{}}) = "Union{}"
 colorant_string(::Type{C}) where {C<:Colorant} = string(nameof(C))
 function colorant_string_with_eltype(::Type{C}) where {C<:Colorant}
     io = IOBuffer()
-    colorant_string_with_eltype(io, C)
+    show_colorant_string_with_eltype(io, C)
     String(take!(io))
 end
-colorant_string_with_eltype(io::IO, ::Type{Union{}}) = show(io, Union{})
-function colorant_string_with_eltype(io::IO, ::Type{C}) where {C<:Colorant}
-    if isconcretetype(C)
+
+show_colorant_string_with_eltype(io::IO, ::Type{Union{}}) = show(io, Union{})
+function show_colorant_string_with_eltype(io::IO, ::Type{C}) where {C<:Colorant}
+    if !isconcretetype(C) || isempty(C.parameters)
+        print(io, C)
+    else
         print(io, colorant_string(C))
         print(io, '{')
         showcoloranttype(io, eltype(C))
         print(io, '}')
-    else
-        print(io, C)
     end
 end
-# Nonparametric types
-colorant_string_with_eltype(io::IO, ::Type{Gray24})  = print(io, "Gray24")
-colorant_string_with_eltype(io::IO, ::Type{AGray32}) = print(io, "AGray32")
-colorant_string_with_eltype(io::IO, ::Type{RGB24})   = print(io, "RGB24")
-colorant_string_with_eltype(io::IO, ::Type{ARGB32})  = print(io, "ARGB32")
 
 showcoloranttype(io, ::Type{Union{}}) = show(io, Union{})
 showcoloranttype(io, ::Type{T}) where {T<:FixedPoint} = FixedPointNumbers.showtype(io, T)

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -56,9 +56,11 @@ hue(c::Union{C,AlphaColor{C},ColorAlpha{C}}) where {C<:Union{Lab,DIN99,DIN99o,DI
 hue(c::Union{C,AlphaColor{C},ColorAlpha{C}}) where {C<:Luv} =
     (h = atand(c.v, c.u); h < 0 ? h + 360 : h)
 
+# fallbacks for compN
+_comp(::Val{N}, c::Colorant) where N = getfield(c, N)
+_comp(::Val{N}, c::AlphaColor) where N = getfield(c, N + 1)
+_comp(::Val{N}, c::AlphaColorN{N}) where N = alpha(c)
 
-# Extract the first, second, and third arguments as you'd
-# pass them to the constructor
 """
 `comp1(c)` extracts the first component you'd pass to the constructor
 of the corresponding object.  For most color types without an alpha
@@ -72,28 +74,32 @@ Specifically, for any `Color{T,3}`,
 
 returns true.
 """
-comp1(c::AbstractRGB) = red(c)
-comp1(c::Union{AlphaColor{C},ColorAlpha{C}}) where {C<:AbstractRGB} = red(c)
-comp1(c::Union{Color,ColorAlpha}) = getfield(c, 1)
-comp1(c::AlphaColor) = getfield(c, 2)
-comp1(c::AGray32) = gray(c)
+comp1(c) = _comp(Val(1), c)
+comp1(c::Union{AbstractRGB, TransparentRGB}) = red(c)
+comp1(c::Union{AbstractGray, TransparentGray}) = gray(c)
 
 "`comp2(c)` extracts the second constructor argument (see `comp1`)."
-comp2(c::AbstractRGB) = green(c)
-comp2(c::Union{AlphaColor{C},ColorAlpha{C}}) where {C<:AbstractRGB} = green(c)
-comp2(c::Union{Color,ColorAlpha}) = getfield(c, 2)
-comp2(c::AlphaColor) = getfield(c, 3)
+comp2(c) = _comp(Val(2), c)
+comp2(c::Union{AbstractRGB, TransparentRGB}) = green(c)
 
 "`comp3(c)` extracts the third constructor argument (see `comp1`)."
-comp3(c::AbstractRGB) = blue(c)
-comp3(c::Union{AlphaColor{C},ColorAlpha{C}}) where {C<:AbstractRGB} = blue(c)
-comp3(c::Union{Color,ColorAlpha}) = getfield(c, 3)
-comp3(c::AlphaColor) = getfield(c, 4)
+comp3(c) = _comp(Val(3), c)
+comp3(c::Union{AbstractRGB, TransparentRGB}) = blue(c)
+
+"`comp4(c)` extracts the fourth constructor argument (see `comp1`)."
+comp4(c) = _comp(Val(4), c)
+comp4(c::AbstractRGB) = throw(BoundsError(c, 4)) # for XRGB/RGBX
+
+"`comp5(c)` extracts the fifth constructor argument (see `comp1`)."
+comp5(c) = _comp(Val(5), c)
+
 
 "`color(c)` extracts the opaque color component from a Colorant (e.g., omits the alpha channel, if present)."
 color(c::Color) = c
-color(c::TransparentColor{C,T,4}) where {C,T} = C(comp1(c), comp2(c), comp3(c))
-color(c::TransparentColor{C,T,2}) where {C,T} = C(comp1(c))
+color(c::TransparentColorN{2,C}) where C = C(comp1(c))
+color(c::TransparentColorN{3,C}) where C = C(comp1(c), comp2(c))
+color(c::TransparentColorN{4,C}) where C = C(comp1(c), comp2(c), comp3(c))
+color(c::TransparentColorN{5,C}) where C = C(comp1(c), comp2(c), comp3(c), comp4(c))
 
 # Some of these traits exploit a nice trick: for subtypes, walk up the
 # type hierarchy until we get to a stage where we can define the

--- a/test/show.jl
+++ b/test/show.jl
@@ -2,6 +2,20 @@ using ColorTypes
 using ColorTypes.FixedPointNumbers
 using Test
 
+# dummy type for testing 2-component color
+struct AnaglyphColor{T} <: Color{T,2} # not `TransparentGray`
+    left::T; right::T
+end
+# dummy type for testing 4-component color
+struct CMYK{T} <: Color{T,4} # not `Transparent3`
+    c::T; m::T; y::T; k::T
+end
+# dummy type for testing 5-component color
+struct ACMYK{T} <: AlphaColor{CMYK{T},T,5}
+    alpha::T; c::T; m::T; y::T; k::T
+    ACMYK{T}(c, m, y, k, alpha=1) where T = new{T}(alpha, c, m, y, k)
+end
+
 @testset "single color" begin
     iob = IOBuffer()
     cf  = RGB{Float32}(0.32218,0.14983,0.87819)
@@ -31,6 +45,8 @@ using Test
     @test String(take!(iob)) == "RGB24(0.4N0f8,0.2N0f8,0.8N0f8)"
     show(iob, ARGB32(0.4,0.2,0.8,1.0))
     @test String(take!(iob)) == "ARGB32(0.4N0f8,0.2N0f8,0.8N0f8,1.0N0f8)"
+    show(IOContext(iob, :compact => true), ARGB32(0.4,0.2,0.8,1.0))
+    @test String(take!(iob)) == "ARGB32(0.4,0.2,0.8,1.0)"
 
     show(iob, Gray(0.8))
     @test String(take!(iob)) == "Gray{Float64}(0.8)"
@@ -41,7 +57,14 @@ using Test
     show(iob, Gray24(0.4))
     @test String(take!(iob)) == "Gray24(0.4N0f8)"
     show(iob, AGray32(0.8))
-    @test String(take!(iob)) == "AGray32{N0f8}(0.8,1.0)"
+    @test String(take!(iob)) == "AGray32(0.8N0f8,1.0N0f8)"
+
+    show(iob, AnaglyphColor{Float32}(0.4, 0.2))
+    @test String(take!(iob)) == "AnaglyphColor{Float32}(0.4f0,0.2f0)"
+    show(iob, CMYK{Float64}(0.1, 0.2, 0.3, 0.4))
+    @test String(take!(iob)) == "CMYK{Float64}(0.1,0.2,0.3,0.4)"
+    show(iob, ACMYK{N0f8}(0.2, 0.4, 0.6, 0.8))
+    @test String(take!(iob)) == "ACMYK{N0f8}(0.2,0.4,0.6,0.8,1.0)"
 end
 
 @testset "collection of colors" begin

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -3,6 +3,21 @@ using ColorTypes.FixedPointNumbers
 using Test
 using ColorTypes: ColorTypeResolutionError
 
+# dummy types
+struct C2{T} <: Color{T,2}
+    c1::T; c2::T
+end
+struct C2A{T} <: ColorAlpha{C2{T},T,3}
+    c1::T; c2::T; alpha::T
+end
+struct C4{T} <: Color{T,4}
+    c1::T; c2::T; c3::T; c4::T
+end
+struct AC4{T} <: AlphaColor{C4{T},T,5}
+    alpha::T; c1::T; c2::T; c3::T; c4::T
+    AC4{T}(c1, c2, c3, c4, alpha=1) where T = new{T}(alpha, c1, c2, c3, c4)
+end
+
 @testset "RGB accessors" begin
 
     # This also checks that the constructor order is the same, even if the
@@ -103,6 +118,28 @@ end
     @test hue(HSV(999, 0.4, 0.6)) == 999 # without normalization
 end
 
+@testset "compN" begin
+    argb32 = ARGB32(1, 0.5, 0, 0.8)
+    @test comp1(argb32) === 1N0f8
+    @test comp2(argb32) === 0.5N0f8
+    @test comp3(argb32) === 0N0f8
+    @test comp4(argb32) === 0.8N0f8
+    @test_throws BoundsError comp5(argb32)
+    agray32 = AGray32(0.2, 0.8)
+    @test comp1(agray32) === 0.2N0f8
+    @test comp2(agray32) === 0.8N0f8
+    xrgb = XRGB(1, 0.5, 0)
+    @test comp1(xrgb) === 1.0
+    @test comp2(xrgb) === 0.5
+    @test comp3(xrgb) === 0.0
+    @test_throws BoundsError comp4(xrgb)
+    ahsv = AHSV(100f0, 0.4f0, 0.6f0, 0.8f0)
+    @test comp1(ahsv) === 100f0
+    @test comp2(ahsv) === 0.4f0
+    @test comp3(ahsv) === 0.6f0
+    @test comp4(ahsv) === 0.8f0
+end
+
 @testset "color" begin
     @test color(RGB(1, 0.5, 0)) === RGB{Float64}(1, 0.5, 0)
     @test color(RGBA{N0f8}(1, 0.5, 0, 0.8)) === RGB{N0f8}(1, 0.5, 0)
@@ -119,6 +156,9 @@ end
     @test color(AGray{Float32}(0.2, 0.8)) === Gray{Float32}(0.2)
     @test color(Gray24(0.2)) === Gray24(0.2)
     @test color(AGray32(0.2, 0.8)) === Gray24(0.2)
+
+    @test color(C2A{Float64}(0.1, 0.2, 0.8)) === C2{Float64}(0.1, 0.2)
+    @test color(AC4{Float32}(0.1, 0.2, 0.3, 0.4, 0.8)) === C4{Float32}(0.1, 0.2, 0.3, 0.4)
 end
 
 @testset "to_top" begin


### PR DESCRIPTION
This generalizes and simplifies the implementation of `show`.(cf. https://github.com/JuliaGraphics/ColorTypes.jl/issues/179#issuecomment-617117028, https://github.com/JuliaGraphics/ColorTypes.jl/issues/179#issuecomment-617131514)
This also adds `comp4` and `comp5`, and enables `color` for all colors with 5 or fewer components.

For `Transparent3` colors, `comp4` returns the `alpha`s. Therefore, after merging this PR, `mapc`, `reducec` and `mapreducec` can be defined more consistently (in lexical terms).