### PR TITLE
Move type-pirating `convert` methods from ImageCore

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ColorTypes"
 uuid = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
-version = "0.10.3"
+version = "0.11.0"
 
 [deps]
 FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"


### PR DESCRIPTION
This removes 80 invalidations, ref https://github.com/JuliaLang/julia/pull/35922  (EDIT, oops, wrote 35915 first)

This will be breaking so I've bumped the version in anticipation. We might want to merge this only when we're ready to release the next breaking version.