### PR TITLE
Add component accessor `comp4`/`comp5`

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,8 +402,8 @@ greater detail); just type `?ccolor` at the REPL.
 - `alpha` extracts the alpha channel from any `Color` object
   (returning 1 if there is no alpha channel)
 
-- `comp1`, `comp2`, and `comp3` extract color components in the order
-  expected by the constructor
+- `comp1`, `comp2`, `comp3`, `comp4` and `comp5` extract color components in the
+  order expected by the constructor
 
 ### Functions
 

--- a/src/ColorTypes.jl
+++ b/src/ColorTypes.jl
@@ -37,7 +37,7 @@ export base_color_type, base_colorant_type, ccolor, color, color_type, parametri
 export alphacolor, coloralpha
 export alpha, red, green, blue, gray   # accessor functions that generalize to RGB24, etc.
 export chroma, hue
-export comp1, comp2, comp3
+export comp1, comp2, comp3, comp4, comp5
 export mapc, reducec, mapreducec, gamutmax, gamutmin
 
 include("types.jl")

--- a/test/operations.jl
+++ b/test/operations.jl
@@ -2,6 +2,11 @@ using ColorTypes
 using ColorTypes.FixedPointNumbers
 using Test
 
+# dummy type
+struct C5{T} <: Color{T,5}
+    c1::T; c2::T; c3::T; c4::T; c5::T
+end
+
 @testset "rand" begin
     @testset "rand($T)" for T in (
             Gray{N0f8}, Gray{N2f6}, Gray{N0f16}, Gray{N2f14}, Gray{N0f32}, Gray{N2f30},
@@ -55,12 +60,15 @@ end
     @test @inferred(mapc(x->2x, RGB{N0f8}(0.04,0.2,0.3))) === RGB(map(x->2*N0f8(x), (0.04,0.2,0.3))...)
     @test @inferred(mapc(sqrt, RGBA{N0f8}(0.04,0.2,0.3,0.7))) === RGBA(map(x->sqrt(N0f8(x)), (0.04,0.2,0.3,0.7))...)
     @test @inferred(mapc(x->1.5f0x, RGBA{N0f8}(0.04,0.2,0.3,0.4))) === RGBA(map(x->1.5f0*N0f8(x), (0.04,0.2,0.3,0.4))...)
+    @test @inferred(mapc(sqrt, C5{N0f8}(0.04,0.2,0.3,0.7,0.1))) === C5(map(x->sqrt(N0f8(x)), (0.04,0.2,0.3,0.7,0.1))...)
 
     @test @inferred(mapc(max, Gray{N0f8}(0.2), Gray{N0f8}(0.3))) === Gray{N0f8}(0.3)
     @test @inferred(mapc(-, AGray{Float32}(0.3), AGray{Float32}(0.2))) === AGray{Float32}(0.3f0-0.2f0,0.0)
     @test @inferred(mapc(min, RGB{N0f8}(0.2,0.8,0.7), RGB{N0f8}(0.5,0.2,0.99))) === RGB{N0f8}(0.2,0.2,0.7)
     @test @inferred(mapc(+, RGBA{N0f8}(0.2,0.8,0.7,0.3), RGBA{Float32}(0.5,0.2,0.99,0.5))) === RGBA(0.5f0+N0f8(0.2),0.2f0+N0f8(0.8),0.99f0+N0f8(0.7),0.5f0+N0f8(0.3))
     @test @inferred(mapc(+, HSVA(0.1,0.8,0.3,0.5), HSVA(0.5,0.5,0.5,0.3))) === HSVA(0.1+0.5,0.8+0.5,0.3+0.5,0.5+0.3)
+    @test @inferred(mapc(+, C5(0.1,0.8,0.3,0.5,0.2), C5(0.5,0.5,0.5,0.5,0.5))) === C5(0.1+0.5,0.8+0.5,0.3+0.5,0.5+0.5,0.2+0.5)
+
     @test_throws ArgumentError mapc(min, RGB{N0f8}(0.2,0.8,0.7), BGR{N0f8}(0.5,0.2,0.99))
     @test @inferred(mapc(abs, -2)) === 2
 end
@@ -72,6 +80,7 @@ end
     @test @inferred(reducec(+, 0.0, AGray(0.3, 0.8))) === 0.3 + 0.8
     @test @inferred(reducec(+, 0.0, RGB(0.3, 0.8, 0.5))) === (0.3 + 0.8) + 0.5
     @test @inferred(reducec(+, 0.0, RGBA(0.3, 0.8, 0.5, 0.7))) === ((0.3 + 0.8) + 0.5) + 0.7
+    @test @inferred(reducec(+, 0.0, C5(0.3, 0.8, 0.5, 0.7, 0.2))) === (((0.3 + 0.8) + 0.5) + 0.7) + 0.2
     @test @inferred(reducec(&, true, Gray(true)))
     @test !(@inferred(reducec(&, false, Gray(true))))
     @test !(@inferred(reducec(&, true, Gray(false))))
@@ -90,6 +99,8 @@ end
     @test @inferred(mapreducec(x->x^2, +, 0.0, AGray(0.3, 0.8))) === 0.3^2 + 0.8^2
     @test @inferred(mapreducec(x->x^2, +, 0.0, RGB(0.3, 0.8, 0.5))) === (0.3^2 + 0.8^2) + 0.5^2
     @test @inferred(mapreducec(x->x^2, +, 0.0, RGBA(0.3, 0.8, 0.5, 0.7))) === ((0.3^2 + 0.8^2) + 0.5^2) + 0.7^2
+    @test @inferred(mapreducec(x->x^2, +, 0.0, C5(0.3, 0.8, 0.5, 0.7, 0.2))) === (((0.3^2 + 0.8^2) + 0.5^2) + 0.7^2) + 0.2^2
+
     @test !(@inferred(mapreducec(x->!x, &, true, Gray(true))))
     @test !(@inferred(mapreducec(x->!x, &, false, Gray(true))))
     @test @inferred(mapreducec(x->!x, &, true, Gray(false)))

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -3,6 +3,21 @@ using ColorTypes.FixedPointNumbers
 using Test
 using ColorTypes: ColorTypeResolutionError
 
+# dummy types
+struct C2{T} <: Color{T,2}
+    c1::T; c2::T;
+end
+struct C2A{T} <: ColorAlpha{C2{T},T,3}
+    c1::T; c2::T; alpha::T
+end
+struct C4{T} <: Color{T,4}
+    c1::T; c2::T; c3::T; c4::T
+end
+struct AC4{T} <: AlphaColor{C4{T},T,5}
+    alpha::T; c1::T; c2::T; c3::T; c4::T
+    AC4{T}(c1, c2, c3, c4, alpha=1) where T = new{T}(alpha, c1, c2, c3, c4)
+end
+
 @testset "RGB accessors" begin
 
     # This also checks that the constructor order is the same, even if the
@@ -103,6 +118,34 @@ end
     @test hue(HSV(999, 0.4, 0.6)) == 999 # without normalization
 end
 
+@testset "compN" begin
+    argb32 = ARGB32(1, 0.5, 0, 0.8)
+    @test comp1(argb32) === 1N0f8
+    @test comp2(argb32) === 0.5N0f8
+    @test comp3(argb32) === 0N0f8
+    @test comp4(argb32) === 0.8N0f8
+    @test_throws BoundsError comp5(argb32)
+    agray32 = AGray32(0.2, 0.8)
+    @test comp1(agray32) === 0.2N0f8
+    @test comp2(agray32) === 0.8N0f8
+    xrgb = XRGB(1, 0.5, 0)
+    @test comp1(xrgb) === 1.0
+    @test comp2(xrgb) === 0.5
+    @test comp3(xrgb) === 0.0
+    @test_throws BoundsError comp4(xrgb)
+    ahsv = AHSV(100f0, 0.4f0, 0.6f0, 0.8f0)
+    @test comp1(ahsv) === 100f0
+    @test comp2(ahsv) === 0.4f0
+    @test comp3(ahsv) === 0.6f0
+    @test comp4(ahsv) === 0.8f0
+    ac4 = AC4{Float32}(0.1, 0.2, 0.3, 0.4, 0.5)
+    @test comp1(ac4) === 0.1f0
+    @test comp2(ac4) === 0.2f0
+    @test comp3(ac4) === 0.3f0
+    @test comp4(ac4) === 0.4f0
+    @test comp5(ac4) === 0.5f0
+end
+
 @testset "color" begin
     @test color(RGB(1, 0.5, 0)) === RGB{Float64}(1, 0.5, 0)
     @test color(RGBA{N0f8}(1, 0.5, 0, 0.8)) === RGB{N0f8}(1, 0.5, 0)
@@ -119,6 +162,9 @@ end
     @test color(AGray{Float32}(0.2, 0.8)) === Gray{Float32}(0.2)
     @test color(Gray24(0.2)) === Gray24(0.2)
     @test color(AGray32(0.2, 0.8)) === Gray24(0.2)
+
+    @test color(C2A{Float64}(0.1, 0.2, 0.8)) === C2{Float64}(0.1, 0.2)
+    @test color(AC4{Float32}(0.1, 0.2, 0.3, 0.4, 0.8)) === C4{Float32}(0.1, 0.2, 0.3, 0.4)
 end
 
 @testset "to_top" begin


### PR DESCRIPTION
This is a modified version of part of PR #189, but this does not change the `show()`.

In the future, I want to be able to get an iterator or tuple of the components (cf. #190, https://github.com/JuliaGraphics/ColorVectorSpace.jl/pull/131#discussion_r443177446).

