### PR TITLE
Generalize `show` for colors with uncommon components

### DIFF
--- a/src/show.jl
+++ b/src/show.jl
@@ -1,49 +1,32 @@
-show(io::IO, c::Colorant) = get(io, :compact, false) ? _showcompact(io, c) : _show(io, c)
-show(io::IO, c::ColorantNormed) = show_normed(io, c)
 
-# Nonparametric types
-show_normed(io::IO, c::Gray24) = print(io, "Gray24(", gray(c), ')')
-show_normed(io::IO, c::RGB24)  = print(io, "RGB24(", red(c), ',', green(c), ',', blue(c), ')')
-show_normed(io::IO, c::ARGB32) = print(io, "ARGB32(", red(c), ',', green(c), ',', blue(c), ',', alpha(c), ')')
+function show(io::IO, c::Colorant)
+    show_colorant_string_with_eltype(io, typeof(c))
+    _show_components(io, c)
+end
 
-# FIXME: handle `Color` and `TransparentColor` correctly
-#       (e.g. `Color{T,4}` such as CMYK is different from `Transparent3`).
-for N = 1:4
-    component = N >= 3 ? (:comp1, :comp2, :comp3, :alpha) : (:comp1, :alpha)
-    printargs = Array{Any}(undef, 2, N)
+# Special handling for Normed types: don't print the giant type name
+function show(io::IO, c::ColorantNormed)
+    show_colorant_string_with_eltype(io, typeof(c))
+    if typeof(c) <: Union{RGB24, ARGB32, Gray24} # isempty(typeof(c).parameters) # Nonparametric types
+        _show_components(io, c) # with trailing "N0f8" unless :compat=>true
+    else
+        _show_components(IOContext(io, :compact=>true), c)
+    end
+end
+
+function _show_components(io::IO, c::ColorantN{N}) where N
+    comp_n = (comp1, comp2, comp3, comp4, comp5)
+    print(io, '(')
     for i = 1:N
-        printargs[1,i] = :(show(io, $(component[i])(c)))
-        chr = i < N ? ',' : ')'
-        printargs[2,i] = :(print(io, $chr))
-    end
-    @eval begin
-        function _show(io::IO, c::Colorant{T,$N}) where T
-            print(io, colorant_string(typeof(c)), "{", T, "}(")
-            $(printargs[:]...)
-        end
-    end
-    for i = 1:N
-        printargs[1,i] = :(show(IOContext(io, :compact => true), $(component[i])(c)))
-    end
-    @eval begin
-        function _showcompact(io::IO, c::Colorant{T,$N}) where T
-            print(io, colorant_string(typeof(c)), "{", T, "}(")
-            $(printargs[:]...)
-        end
-        # Special handling for Normed types: don't print the giant type name
-        function show_normed(io::IO, c::Colorant{FixedPointNumbers.Normed{T,f},$N}) where {T,f}
-            print(io, colorant_string(typeof(c)), '{')
-            FixedPointNumbers.showtype(io, eltype(typeof(c)))
-            print(io, "}(")
-            $(printargs[:]...)
-        end
+        show(io, (comp_n[i])(c))
+        print(io, i < N ? ',' : ')') # without spaces
     end
 end
 
 function Base.showarg(io::IO, a::Array{C}, toplevel) where C<:Colorant
     toplevel || print(io, "::")
     print(io, "Array{")
-    colorant_string_with_eltype(io, C)
+    show_colorant_string_with_eltype(io, C)
     print(io, ",$(ndims(a))}")
     toplevel && print(io, " with eltype ", C)
 end
@@ -53,25 +36,25 @@ colorant_string(::Type{Union{}}) = "Union{}"
 colorant_string(::Type{C}) where {C<:Colorant} = string(nameof(C))
 function colorant_string_with_eltype(::Type{C}) where {C<:Colorant}
     io = IOBuffer()
-    colorant_string_with_eltype(io, C)
+    show_colorant_string_with_eltype(io, C)
     String(take!(io))
 end
-colorant_string_with_eltype(io::IO, ::Type{Union{}}) = show(io, Union{})
-function colorant_string_with_eltype(io::IO, ::Type{C}) where {C<:Colorant}
-    if isconcretetype(C)
+
+# for backward compatibility (Some other packages use this method.)
+colorant_string_with_eltype(io::IO, ::Type{C}) where {C<:Colorant} =
+    show_colorant_string_with_eltype(io, C)
+
+show_colorant_string_with_eltype(io::IO, ::Type{Union{}}) = show(io, Union{})
+function show_colorant_string_with_eltype(io::IO, ::Type{C}) where {C<:Colorant}
+    if !isconcretetype(C) || isempty(C.parameters)
+        print(io, C)
+    else
         print(io, colorant_string(C))
         print(io, '{')
         showcoloranttype(io, eltype(C))
         print(io, '}')
-    else
-        print(io, C)
     end
 end
-# Nonparametric types
-colorant_string_with_eltype(io::IO, ::Type{Gray24})  = print(io, "Gray24")
-colorant_string_with_eltype(io::IO, ::Type{AGray32}) = print(io, "AGray32")
-colorant_string_with_eltype(io::IO, ::Type{RGB24})   = print(io, "RGB24")
-colorant_string_with_eltype(io::IO, ::Type{ARGB32})  = print(io, "ARGB32")
 
 showcoloranttype(io, ::Type{Union{}}) = show(io, Union{})
 showcoloranttype(io, ::Type{T}) where {T<:FixedPoint} = FixedPointNumbers.showtype(io, T)

--- a/test/show.jl
+++ b/test/show.jl
@@ -2,6 +2,20 @@ using ColorTypes
 using ColorTypes.FixedPointNumbers
 using Test
 
+# dummy type for testing 2-component color
+struct AnaglyphColor{T} <: Color{T,2} # not `TransparentGray`
+    left::T; right::T
+end
+# dummy type for testing 4-component color
+struct CMYK{T} <: Color{T,4} # not `Transparent3`
+    c::T; m::T; y::T; k::T
+end
+# dummy type for testing 5-component color
+struct ACMYK{T} <: AlphaColor{CMYK{T},T,5}
+    alpha::T; c::T; m::T; y::T; k::T
+    ACMYK{T}(c, m, y, k, alpha=1) where T = new{T}(alpha, c, m, y, k)
+end
+
 @testset "single color" begin
     iob = IOBuffer()
     cf  = RGB{Float32}(0.32218,0.14983,0.87819)
@@ -31,6 +45,8 @@ using Test
     @test String(take!(iob)) == "RGB24(0.4N0f8,0.2N0f8,0.8N0f8)"
     show(iob, ARGB32(0.4,0.2,0.8,1.0))
     @test String(take!(iob)) == "ARGB32(0.4N0f8,0.2N0f8,0.8N0f8,1.0N0f8)"
+    show(IOContext(iob, :compact => true), ARGB32(0.4,0.2,0.8,1.0))
+    @test String(take!(iob)) == "ARGB32(0.4,0.2,0.8,1.0)"
 
     show(iob, Gray(0.8))
     @test String(take!(iob)) == "Gray{Float64}(0.8)"
@@ -41,7 +57,14 @@ using Test
     show(iob, Gray24(0.4))
     @test String(take!(iob)) == "Gray24(0.4N0f8)"
     show(iob, AGray32(0.8))
-    @test String(take!(iob)) == "AGray32{N0f8}(0.8,1.0)"
+    @test_broken String(take!(iob)) == "AGray32(0.8N0f8,1.0N0f8)"
+
+    show(iob, AnaglyphColor{Float32}(0.4, 0.2))
+    @test String(take!(iob)) == "AnaglyphColor{Float32}(0.4f0,0.2f0)"
+    show(iob, CMYK{Float64}(0.1, 0.2, 0.3, 0.4))
+    @test String(take!(iob)) == "CMYK{Float64}(0.1,0.2,0.3,0.4)"
+    show(iob, ACMYK{N0f8}(0.2, 0.4, 0.6, 0.8))
+    @test String(take!(iob)) == "ACMYK{N0f8}(0.2,0.4,0.6,0.8,1.0)"
 end
 
 @testset "collection of colors" begin

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -119,12 +119,18 @@ end
 end
 
 @testset "compN" begin
+    g = Gray{Float32}(0.5)
+    @test comp1(g) === 0.5f0
+    @test_throws ArgumentError comp2(g)
+    @test_throws ArgumentError comp3(g)
+    @test_throws ArgumentError comp4(g)
+    @test_throws ArgumentError comp5(g)
     argb32 = ARGB32(1, 0.5, 0, 0.8)
     @test comp1(argb32) === 1N0f8
     @test comp2(argb32) === 0.5N0f8
     @test comp3(argb32) === 0N0f8
     @test comp4(argb32) === 0.8N0f8
-    @test_throws BoundsError comp5(argb32)
+    @test_throws ArgumentError comp5(argb32)
     agray32 = AGray32(0.2, 0.8)
     @test comp1(agray32) === 0.2N0f8
     @test comp2(agray32) === 0.8N0f8
@@ -132,7 +138,8 @@ end
     @test comp1(xrgb) === 1.0
     @test comp2(xrgb) === 0.5
     @test comp3(xrgb) === 0.0
-    @test_throws BoundsError comp4(xrgb)
+    ret = @test_throws ArgumentError comp4(xrgb)
+    @test occursin("3-component color XRGB{Float64} with `comp4`", ret.value.msg)
     ahsv = AHSV(100f0, 0.4f0, 0.6f0, 0.8f0)
     @test comp1(ahsv) === 100f0
     @test comp2(ahsv) === 0.4f0


### PR DESCRIPTION
This is the successor to #198 and the rest of PR #189, but the bug fix for `show(::AGray32)` is removed.