### PR TITLE
Add tests for 1-arg rgb constructors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ColorTypes"
 uuid = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
-version = "0.10.4"
+version = "0.10.5"
 
 [deps]
 FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -578,6 +578,13 @@ end
     @test convert(ARGB32, 0.6, 0.8) === ARGB32(0.6, 0.6, 0.6, 0.8)
 
     @test convert(RGB, 0.6) === RGB(0.6, 0.6, 0.6)
+    @test convert(BGR, 0.6N0f8) === BGR{N0f8}(0.6, 0.6, 0.6)
+    @test_broken convert(ARGB, 0.6) === ARGB(0.6, 0.6, 0.6, 1)
+    @test_broken convert(RGBA, 0.6N0f8) === RGBA{N0f8}(0.6, 0.6, 0.6, 1)
+
+    @test_broken convert(ARGB, 0.6f0, 0.8f0) === ARGB{Float32}(0.6, 0.6, 0.6, 0.8)
+    @test_broken convert(RGBA{Float32}, 0.6, 0.8) === RGBA{Float32}(0.6, 0.6, 0.6, 0.8)
+
 end
 
 @testset "conversions from rgb to rgb" begin

--- a/test/types.jl
+++ b/test/types.jl
@@ -106,6 +106,9 @@ end
                 @test C{N0f8}(val1,val2,val1) === C(0.2N0f8,0.6N0f8,0.2N0f8)
                 @test C{N0f16}(val1,val2,val1) === C(0.2N0f16,0.6N0f16,0.2N0f16)
             end
+            # 1-arg constructor
+            @test C(val1) === C{typeof(val1)}(0.2,0.2,0.2)
+            @test C{N0f8}(val1) === C{N0f8}(0.2,0.2,0.2)
         end
 
         @test_throws ArgumentError C(2,1,0) # integers
@@ -137,6 +140,9 @@ end
                 @test C{N0f8}(val1,val2,val1) === C(0.2N0f8,0.6N0f8,0.2N0f8,1N0f8)
                 @test C{N0f16}(val1,val2,val1,0.8) === C(0.2N0f16,0.6N0f16,0.2N0f16,0.8N0f16)
             end
+            # 1-arg constructor
+            @test_broken C(val1) === C{typeof(val1)}(0.2,0.2,0.2,1)
+            @test_broken C{N0f8}(val1) === C{N0f8}(0.2,0.2,0.2,1)
         end
 
         @test_throws ArgumentError C(2,1,0) # integers
@@ -165,6 +171,7 @@ end
             @test ARGB32(c0) === ARGB32(val1,val2,val1,1)
             @test ARGB32(c0,0.8) === ARGB32(val1,val2,val1,0.8)
         end
+        # 1-arg constructor
         @test RGB24(val1) === RGB24(0.2,0.2,0.2)
         @test ARGB32(val1) === ARGB32(0.2,0.2,0.2,1)
     end


### PR DESCRIPTION
We are going to support `alpha(::Number)` (cf. PR #177).
This adds tests for the 1-arg rgb/transparent-rgb constructors. Some broken tests should be fixed by PR #177.

I'm concerned about supporting 2-arg transparent rgb construcctors. The 2-arg constructors are not the abbreviations for the 3-arg/4-arg constructors.
```julia
julia> ARGB(Gray(1), 0.5)
ARGB{N0f8}(1.0,1.0,1.0,0.502)

julia> ARGB(1, 0.5) # Is this needed?
ERROR: MethodError: no method matching ARGB(::Int64, ::Float64)
```