### PR TITLE
Reimplement `parameter_upper_bound`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ColorTypes"
 uuid = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
-version = "0.10.6"
+version = "0.10.7"
 
 [deps]
 FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"


### PR DESCRIPTION
Fixes #208

This reimplements the function, although the implementation still depends on non-public APIs (i.e. `Base.unwrap_unionall` and `Base.rewrap_unionall`).
This also generalizes `eltypes_supported` for non-parametric color types.

We haven't merged the breaking changes yet, so I plan to release v0.10.7.