### PR TITLE
Suppress display of module names for invisible types

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ColorTypes"
 uuid = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
-version = "0.10.7"
+version = "0.10.8"
 
 [deps]
 FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"

--- a/src/show.jl
+++ b/src/show.jl
@@ -7,18 +7,21 @@ end
 # Special handling for Normed types: don't print the giant type name
 function show(io::IO, c::ColorantNormed)
     show_colorant_string_with_eltype(io, typeof(c))
-    if typeof(c) <: Union{RGB24, ARGB32, Gray24} # isempty(typeof(c).parameters) # Nonparametric types
+    if typeof(c) === base_colorant_type(typeof(c)) # non-parametric
         _show_components(io, c) # with trailing "N0f8" unless :compat=>true
     else
         _show_components(IOContext(io, :compact=>true), c)
     end
 end
 
-function _show_components(io::IO, c::ColorantN{N}) where N
-    comp_n = (comp1, comp2, comp3, comp4, comp5)
+function _show_components(io::IO, c::Colorant{T,N}) where {T, N}
     print(io, '(')
     for i = 1:N
-        show(io, (comp_n[i])(c))
+        i == 1 && show(io, comp1(c))
+        i == 2 && show(io, comp2(c))
+        i == 3 && show(io, comp3(c))
+        i == 4 && show(io, comp4(c))
+        i == 5 && show(io, comp5(c))
         print(io, i < N ? ',' : ')') # without spaces
     end
 end
@@ -46,10 +49,13 @@ colorant_string_with_eltype(io::IO, ::Type{C}) where {C<:Colorant} =
 
 show_colorant_string_with_eltype(io::IO, ::Type{Union{}}) = show(io, Union{})
 function show_colorant_string_with_eltype(io::IO, ::Type{C}) where {C<:Colorant}
-    if !isconcretetype(C) || isempty(C.parameters)
-        print(io, C)
+    if !isconcretetype(C)
+        get(io, :compact, false) && return show(io, C)
+        show(IOContext(io, :compact => true), C) # w/o module names
+    elseif C === base_colorant_type(C) # non-parametric
+        print(io, nameof(C))
     else
-        print(io, colorant_string(C))
+        print(io, nameof(C))
         print(io, '{')
         showcoloranttype(io, eltype(C))
         print(io, '}')

--- a/test/show.jl
+++ b/test/show.jl
@@ -57,7 +57,7 @@ end
     show(iob, Gray24(0.4))
     @test String(take!(iob)) == "Gray24(0.4N0f8)"
     show(iob, AGray32(0.8))
-    @test_broken String(take!(iob)) == "AGray32(0.8N0f8,1.0N0f8)"
+    @test String(take!(iob)) == "AGray32(0.8N0f8,1.0N0f8)"
 
     show(iob, AnaglyphColor{Float32}(0.4, 0.2))
     @test String(take!(iob)) == "AnaglyphColor{Float32}(0.4f0,0.2f0)"


### PR DESCRIPTION
In PR #174 (v0.10.0), the module names were displayed for invisible non-concrete types. In PR #199, non-parametric types also joined the problem. This suppresses the display of module names.

This also completely fixes the problem with display of `AGray32`. (It was accidentally half-fixed in PR #199.)

```julia
julia> import ColorTypes # not `using`

julia> ColorTypes.RGB[] # v0.10.0
0-element Array{ColorTypes.RGB,1} with eltype ColorTypes.RGB

julia> ColorTypes.RGB24[] # v0.10.6
0-element Array{ColorTypes.RGB24,1} with eltype ColorTypes.RGB24

julia> ColorTypes.RGB24[] # this PR
0-element Array{RGB24,1} with eltype ColorTypes.RGB24
```
```julia
julia> AGray32(1) # v0.10.0 or earlier
AGray32{N0f8}(1.0,1.0)

julia> AGray32(1) # v0.10.6 Damn!
AGray32(1.0,1.0)

julia> AGray32(1) # this PR
AGray32(1.0N0f8,1.0N0f8)
```