### PR TITLE
Implement `<` in addition to `isless`

### DIFF
--- a/src/ColorTypes.jl
+++ b/src/ColorTypes.jl
@@ -6,7 +6,7 @@ using Base: @pure
 
 const Fractional = Union{AbstractFloat, FixedPoint}
 
-import Base: ==, isapprox, hash, convert, eltype, length, show, oneunit, zero, reinterpret, getindex
+import Base: ==, <, isless, isapprox, hash, convert, eltype, length, show, oneunit, zero, reinterpret, getindex
 using Random
 import Random: rand
 

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -514,5 +514,10 @@ end
 
 Base.broadcastable(x::Colorant) = Ref(x)
 
-Base.isless(a::AbstractGray, b::AbstractGray) =
-    isless(gray(a), gray(b))
+isless(a::AbstractGray, b::AbstractGray) = isless(gray(a), gray(b))
+isless(a::AbstractGray, b::Real)         = isless(gray(a), b)
+isless(a::Real,         b::AbstractGray) = isless(a,       gray(b))
+
+<(a::AbstractGray, b::AbstractGray) = gray(a) < gray(b)
+<(a::AbstractGray, b::Real)         = gray(a) < b
+<(a::Real,         b::AbstractGray) = a       < gray(b)

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -682,6 +682,8 @@ end
 
 @testset "isless" begin
     @test Gray(0.8) < Gray(0.9)
+    @test Gray(0.8) <      0.9
+    @test      0.8  < Gray(0.9)
     @test Gray(0.8) <= Gray(0.9)
     @test Gray(0.9) <= Gray(0.9)
     @test Gray(0.9) > Gray(0.8)
@@ -715,6 +717,15 @@ end
     @test Gray(0.9f0) > Gray(0.8N0f8)
     @test Gray(0.9f0) >= Gray(0.8N0f8)
     # @test Gray(0.9f0) >= Gray(0.9N0f8) is not true, since 0.9N0f8 = 0.902
+
+    @test (Gray(0.3) < Gray(NaN)) == (0.3 < NaN)
+    @test (Gray(NaN) < Gray(0.3)) == (NaN < 0.3)
+    @test isless(Gray(0.3), Gray(NaN)) == isless(0.3, NaN)
+    @test isless(Gray(NaN), Gray(0.3)) == isless(NaN, 0.3)
+    @test isless(Gray(0.3), NaN) == isless(0.3, NaN)
+    @test isless(Gray(NaN), 0.3) == isless(NaN, 0.3)
+    @test isless(0.3, Gray(NaN)) == isless(0.3, NaN)
+    @test isless(NaN, Gray(0.3)) == isless(NaN, 0.3)
 
     # transparent gray doesn't support comparison
     @test_throws MethodError GrayA(0.8, 0.4) < GrayA(0.9, 0.4)


### PR DESCRIPTION
Note: this replaces #186 for `<`. I'll add the rest in separate PRs.

#160 "moved" isless from ColorVectorSpace to ColorTypes, but didn't likewise move <. Because < falls back to isless,
this meant that comparisons like Gray(0.3) < Gray(NaN) returned a different answer than 0.3 < NaN.

This is breaking, because moving methods from one package to another is breaking unless all compatible versions of the "upstream" package (ColorVectorSpace) were designed with the possibility that these methods would be present in this package. That's not the case, so we need to introduce an incompatibility. Worth nothing that if we put ColorTypes, Colors, and ColorVectorSpace into a single multi-package repository, we might be able to such a transfer in a non-breaking way.