### PR TITLE
Improve `rand` speed and add some additional precompiles

### DIFF
--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -91,12 +91,27 @@ function _precompile_()
     for T in eltypes, C in pctypes
         @assert precompile(Tuple{typeof(rand),Type{C{T}},Tuple{Int}})
         @assert precompile(Tuple{typeof(rand),Type{C{T}},Tuple{Int,Int}})
+        @assert precompile(Tuple{typeof(rand),Type{C{T}},Tuple{Int,Int,Int}})
         @assert precompile(Tuple{typeof(rand),Type{C{T}},Int})
         @assert precompile(Tuple{typeof(rand),Type{C{T}},Int,Int})
+        @assert precompile(Tuple{typeof(rand),Type{C{T}},Int,Int,Int})
     end
     for C in cctypes
         @assert precompile(Tuple{typeof(rand),Type{C},Tuple{Int}})
         @assert precompile(Tuple{typeof(rand),Type{C},Tuple{Int,Int}})
+    end
+    @assert precompile(Tuple{typeof(rand),Type{Gray{Bool}},Tuple{Int}})
+    @assert precompile(Tuple{typeof(rand),Type{Gray{Bool}},Tuple{Int,Int}})
+    @assert precompile(Tuple{typeof(rand),Type{Gray{Bool}},Tuple{Int,Int,Int}})
+    # show
+    for IO in (IOBuffer, IOContext{IOBuffer}, IOContext{Base.TTY})
+        for T in eltypes, C in pctypes
+            @assert precompile(Tuple{typeof(show),IO,C{T}})
+        end
+        for C in cctypes
+            @assert precompile(Tuple{typeof(show),IO,C})
+        end
+        @assert precompile(Tuple{typeof(show),IO,Gray{Bool}})
     end
     # FIXME the following do not yet "work", meaning you can issue these precompile directives but no value comes of it.
     # Possibly this is https://github.com/JuliaLang/julia/pull/32705, but the actual cause is unknown.


### PR DESCRIPTION
This yields a 3x speed improvement in `rand(RGB{Float32}, sz)` on Julia 1.6:

Before:
```julia
julia> @time rand(RGB{Float32}, (1000, 1000, 10));
  0.387576 seconds (2 allocations: 114.441 MiB)
```

After:
```julia
julia> @time rand(RGB{Float32}, (1000, 1000, 10));
  0.125350 seconds (2 allocations: 114.441 MiB)
```

For the precompiles, some of these take >60ms to infer, so it's nice to get them cached.
