### PR TITLE
Fix "broken" test which may succeed unintentionally

### DIFF
--- a/test/operations.jl
+++ b/test/operations.jl
@@ -58,7 +58,7 @@ end
     @test_broken rand(ARGB32)
     @test_broken rand(MersenneTwister(), RGB{N0f8})
     @test_broken rand!(Gray{Float32}[0.0, 0.1])
-    @test_broken all(all_in_range, rand(ARGB{Q3f12}, 1))
+    @test_broken all(all_in_range, rand(ARGB{Q3f12}, 10, 10))
     @test_broken all_in_range(LCHab(50, 10, 359))
     @test_broken all_in_range(YIQ(0.5, 0.59, 0.0))
     @test_broken !all_in_range(YIQ(0.5, 0.0, -0.53))


### PR DESCRIPTION
Theoretically, there is still a chance of unintentional success, but the probability is small enough.

```julia
julia> rand(Gray{Q3f12})  # returns a negative value about 50% of the time.
Gray{Q3f12}(-0.3162Q3f12)
```

Fixes #225