### PR TITLE
Version 0.10.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ColorTypes"
 uuid = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
-version = "0.10.9"
+version = "0.10.10"
 
 [deps]
 FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"


### PR DESCRIPTION
This is the last checkpoint for the release of ColorTypes v0.11. (I think I've declared something similar in the past. :sweat_smile:)

The following is the correspondence between the versions I had assumed.
|ColorTypes      | v0.10.10 | v0.11.0 (#213, #186?) | v0.12.0 (#177, #206, #222, #197?)|
|:---------------|:---------|:----------------------|:--------|
|Colors          |(v0.12.6) | v0.12.7               | v0.13.0 |
|ColorVectorSpace|(v0.9.1)  | v0.9.2                | v0.9.3  |

The important thing is that #222 will break a lot of doctests, so have it guarded by Colors.jl's cap. So I am concerned about the end of ColorTypes v0.11, i.e. the start of ColorTypes v0.12. (https://github.com/JuliaGraphics/ColorTypes.jl/pull/213#issuecomment-673599021)
There is room for debate as to what to include in the ColorTypes v0.11 series, but I think it is straightforward to limit it to only ColorVectorSpace related items. They do not affect Colors. (https://github.com/JuliaGraphics/ColorTypes.jl/pull/213#issuecomment-673576572)