### PR TITLE
Generalize `==`

### DIFF
--- a/src/traits.jl
+++ b/src/traits.jl
@@ -449,58 +449,33 @@ function ccolor(::Type{Cdest}, ::Type{Csrc}) where {Cdest<:Colorant, Csrc<:Union
     return C{Tdef}
 end
 
-### Equality
-function ==(c1::AbstractRGB, c2::AbstractRGB)
-    red(c1) == red(c2) && green(c1) == green(c2) && blue(c1) == blue(c2)
-end
-==(c1::HSV, c2::HSV) = c1.h == c2.h && c1.s == c2.s && c1.v == c2.v
-==(c1::HSI, c2::HSI) = c1.h == c2.h && c1.s == c2.s && c1.i == c2.i
-==(c1::HSL, c2::HSL) = c1.h == c2.h && c1.s == c2.s && c1.l == c2.l
-==(c1::XYZ, c2::XYZ) = c1.x == c2.x && c1.y == c2.y && c1.z == c2.z
-==(c1::xyY, c2::xyY) = c1.x == c2.x && c1.y == c2.y && c1.Y == c2.Y
-==(c1::Lab, c2::Lab) = c1.l == c2.l && c1.a == c2.a && c1.b == c2.b
-==(c1::Luv, c2::Luv) = c1.l == c2.l && c1.u == c2.u && c1.v == c2.v
-==(c1::LCHab, c2::LCHab) = c1.l == c2.l && c1.c == c2.c && c1.h == c2.h
-==(c1::LCHuv, c2::LCHuv) = c1.l == c2.l && c1.c == c2.c && c1.h == c2.h
-==(c1::DIN99, c2::DIN99) = c1.l == c2.l && c1.a == c2.a && c1.b == c2.b
-==(c1::DIN99d, c2::DIN99d) = c1.l == c2.l && c1.a == c2.a && c1.b == c2.b
-==(c1::DIN99o, c2::DIN99o) = c1.l == c2.l && c1.a == c2.a && c1.b == c2.b
-==(c1::LMS, c2::LMS) = c1.l == c2.l && c1.m == c2.m && c1.s == c2.s
-==(c1::YIQ, c2::YIQ) = c1.y == c2.y && c1.i == c2.i && c1.q == c2.q
-==(c1::YCbCr, c2::YCbCr) = c1.y == c2.y && c1.cb == c2.cb && c1.cr == c2.cr
+struct BoolTuple end
+@inline BoolTuple(args::Bool...) = args
 
-==(x::AbstractGray, y::AbstractGray) = gray(x) == gray(y)
+### Equality
+_is_same_colorspace(a, b) = base_colorant_type(a) === base_colorant_type(b)
+_is_same_colorspace(a::TransparentColor, b::TransparentColor) = base_color_type(a) === base_color_type(b)
+_is_same_colorspace(a::AbstractGray, b::AbstractGray) = true
+_is_same_colorspace(a::TransparentGray, b::TransparentGray) = true
+_is_same_colorspace(a::AbstractRGB, b::AbstractRGB) = true
+_is_same_colorspace(a::TransparentRGB, b::TransparentRGB) = true
+
+function ==(a::ColorantN{N}, b::ColorantN{N}) where {N}
+    _is_same_colorspace(a, b) || return false
+    all(_mapc(BoolTuple, ==, a, b))
+end
 ==(x::Number, y::AbstractGray) = x == gray(y)
 ==(x::AbstractGray, y::Number) = ==(y, x)
 
-function ==(x::TransparentColor, y::TransparentColor)
-    color(x) == color(y) && alpha(x) == alpha(y)
-end
 
-
-struct BoolTuple end
-@inline BoolTuple(args::Bool...) = (args...,)
-
-function _isapprox(a::Colorant, b::Colorant; kwargs...)
+function isapprox(a::ColorantN{N}, b::ColorantN{N}; kwargs...) where {N}
+    _is_same_colorspace(a, b) || return false
     componentapprox(x, y) = isapprox(x, y; kwargs...)
-    all(ColorTypes._mapc(BoolTuple, componentapprox, a, b))
+    all(_mapc(BoolTuple, componentapprox, a, b))
 end
-isapprox(a::C, b::C; kwargs...) where {C<:Colorant} =
-    _isapprox(a, b; kwargs...)
-isapprox(a::Colorant, b::Colorant; kwargs...) =
-    _isapprox(base_colorant_type(a), base_colorant_type(b), a, b; kwargs...)
-_isapprox(::Type{C}, ::Type{C}, a, b; kwargs...) where {C<:Colorant} =
-    _isapprox(a, b; kwargs...)
-_isapprox(::Type{<:AbstractRGB}, ::Type{<:AbstractRGB}, a, b; kwargs...) =
-    _isapprox(RGB(a), RGB(b); kwargs...)
-_isapprox(::Type{<:AbstractGray}, ::Type{<:AbstractGray}, a, b; kwargs...) =
-    isapprox(gray(a), gray(b); kwargs...)
-_isapprox(TA::Type, TB::Type, a, b; kwargs...) = false
-isapprox(x::Number, y::AbstractGray; kwargs...) =
-    isapprox(x, gray(y); kwargs...)
-isapprox(x::AbstractGray, y::Number; kwargs...) =
-    isapprox(y, x; kwargs...)
-
+isapprox(a::Colorant, b::Colorant; kwargs...) = false
+isapprox(a::Number, b::AbstractGray; kwargs...) = isapprox(a, gray(b); kwargs...)
+isapprox(a::AbstractGray, b::Number; kwargs...) = isapprox(b, a; kwargs...)
 
 zero(::Type{C}) where {C<:Gray} = C(0)
 oneunit(::Type{C}) where {C<:Gray} = C(1)

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -666,6 +666,8 @@ end
     @test RGB(0.2, 0.8, 0.4) ≈ RGB(0.2, 0.8 + eps(), 0.4)
     @test RGBA(0.2, 0.8, 0.4, 0.2) ≈ RGBA(0.2, 0.8 + eps(), 0.4, 0.2 - eps())
 
+    @test !isapprox(Gray(1), RGB(1, 1, 1))
+
     c_n0f8 = RGB{N0f8}(0.2, 0.69, 0.4)
     c_f32 = RGB{Float32}(0.2, 0.69, 0.4)
     @test c_n0f8 != c_f32 && c_n0f8 ≈ c_f32


### PR DESCRIPTION
cf. https://github.com/JuliaGraphics/ColorTypes.jl/pull/186#issuecomment-672044220

This would qualify as part of v0.10.x, but in downstream packages, the benefits of the generalization would have to wait until v0.11.0. I'm submitting this PR now because I'm assuming we'll be moving the comparison methods to "operations.jl" or "comparisons.jl" (or something). In other words, this is a decluttering before the move.