### PR TITLE
Version 0.11.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ColorTypes"
 uuid = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
-version = "0.10.12"
+version = "0.11.0"
 
 [deps]
 FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"


### PR DESCRIPTION
#### TODO

- [x] Move `<` and gray-real comparison from ColorVectorSpace (PR #213)
- [x] Move comparison methods to "operations.jl" or something (PR #237)
  - cf. https://github.com/JuliaGraphics/ColorTypes.jl/pull/158#discussion_r376705144
- [x] Move `zero` for `{Abstract|Transparent}RGB` from ColorVectorSpace (PR #238)
- [x] Add `zero`/`oneunit` for more types (PR #238)
- [ ] Make a decision on the definition of `one` (PR #243) --> v0.12
  - cf. issue #235
- [x] Add error hints for color arithmetic (~a part of PR #243~ PR #249)
- [ ] Support `alpha(::Number)`? (PR #177) --> v0.12

Optional
- [x] Move `isfinite`, `isinf`, and `isnan` from ColorVectorSpace (PR #246)
  - They are not related to vector representations.
- [x] Move `nan` from ColorVectorSpace and add support for more types (PR #246)
  - cf. https://github.com/JuliaGraphics/ColorVectorSpace.jl/issues/75
- [x] Move `real(::Type{<:AbstractGray})` from ColorVectorSpace (PR #248)

#### Version table

I'm changing my mind on the policy of postponing PR #243 to ColorTypes v0.12 and releasing the corresponding ColorVectorSpace v0.10. I would like to proceed to ColorTypes v0.12.0 without releasing v0.11.x if possible.

|ColorTypes      | v0.10.10+| v0.11.0 | v0.12.0 |
|:---------------|:---------|:--------|:--------|
|Colors          |(v0.12.6+)| v0.12.8 | v0.13.0 |
|ColorVectorSpace|(v0.9.1+) | v0.9.4  |*v0.10.0*|
