### PR TITLE
Fix inference regression on `eltypes_supported`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ColorTypes"
 uuid = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
-version = "0.10.11"
+version = "0.10.12"
 
 [deps]
 FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -137,8 +137,7 @@ function eltypes_supported(::Type{C}) where {C<:Colorant}
     isconcretetype(C) && C === Cb && return eltype(C)
     _eltypes_supported(Cb, supertype(Cb))
 end
-_eltypes_supported(::Type{<:Color   }, ::Type{C}) where {C<:Color   } = _eltypes_supported(C, supertype(C)) # may help caching
-_eltypes_supported(::Type{<:Colorant}, ::Type{C}) where {C<:Colorant} = _eltypes_supported(C, supertype(C))
+@pure _eltypes_supported(::Type{<:Colorant}, ::Type{C}) where {C<:Colorant} = _eltypes_supported(C, supertype(C))
 _eltypes_supported(::Type{C}, ::Type) where {C<:Colorant} = _parameter_upper_bound(C, 1)
 
 eltypes_supported(c::Colorant) = eltypes_supported(typeof(c))


### PR DESCRIPTION
I am not fully aware of this inference issue, but v0.10.11 affects the testing of ImageCore.jl, so I am releasing this as a quick fix.