### PR TITLE
Add `zero` & `oneunit` for more types

### DIFF
--- a/src/error_hints.jl
+++ b/src/error_hints.jl
@@ -2,10 +2,10 @@
 function register_hints()
     if isdefined(Base, :Experimental) && isdefined(Base.Experimental, :register_error_hint)
         Base.Experimental.register_error_hint(MethodError) do io, exc, argtypes, kwargs
-            if exc.f in (zero, one) && argtypes[1] <: Union{Type{<:AbstractRGB}, AbstractRGB}
+            if exc.f in (one,) && argtypes[1] <: Union{Type{<:AbstractRGB}, AbstractRGB}
                 print(io, "\nYou may need to `using ColorVectorSpace`.")
             end
-            if exc.f in (zeros, ones) && argtypes[1] <: Type{<:AbstractRGB}
+            if exc.f in (ones,) && argtypes[1] <: Type{<:AbstractRGB}
                 print(io, "\nYou may need to `using ColorVectorSpace`.")
             end
         end

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -448,8 +448,21 @@ function ccolor(::Type{Cdest}, ::Type{Csrc}) where {Cdest<:Colorant, Csrc<:Union
     return C{Tdef}
 end
 
-zero(::Type{C}) where {C<:Gray} = C(0)
-oneunit(::Type{C}) where {C<:Gray} = C(1)
+zero(::Type{C}) where {C<:ColorantN{1}} = C(0)
+zero(::Type{C}) where {C<:ColorantN{2}} = C(0, 0)
+zero(::Type{C}) where {C<:ColorantN{3}} = C(0, 0, 0)
+zero(::Type{C}) where {C<:ColorantN{4}} = C(0, 0, 0, 0)
+zero(::Type{C}) where {C<:ColorantN{5}} = C(0, 0, 0, 0, 0)
+zero(c::Colorant) = zero(typeof(c))
+
+oneunit(::Type{C}) where {C<:AbstractGray} = C(1)
+# It's not clear what `oneunit` means for most Color3s,
+# but for AbstractRGB, XYZ, and LMS, it's OK
+oneunit(::Type{C}) where {C<:AbstractRGB}      = C(1, 1, 1)
+oneunit(::Type{C}) where {C<:Union{XYZ, LMS}}  = C(1, 1, 1)
+oneunit(::Type{C}) where {C<:TransparentColor} = C(oneunit(color_type(C)))
+oneunit(::Type{C}) where {C<:Union{AGray, GrayA}} = C(1, 1) # workaround for inconsistent `color_type`
+oneunit(c::Colorant) = oneunit(typeof(c))
 
 function Base.one(::Type{C}) where {C<:Gray}
     Base.depwarn("one($C) will soon switch to returning 1; you might need to switch to `oneunit`", :one)

--- a/test/customtypes.jl
+++ b/test/customtypes.jl
@@ -76,6 +76,11 @@ struct CMYK{T <: Fractional} <: Color{T,4} # not `Transparent3`
     k::T
     CMYK{T}(c::T, m::T, y::T, k::T) where {T} = new{T}(c, m, y, k)
 end
+# TODO: The following should be generated automatically
+CMYK{T}(c, m, y, k) where {T} = CMYK{T}(T(c), T(m), T(y), T(k))
+
+ColorTypes.eltype_default(::Type{<:CMYK}) = N0f8
+Base.oneunit(::Type{C}) where {C <: CMYK} = (isconcretetype(C) ? C : C{N0f8})(1, 1, 1, 1)
 
 # minimal type for testing 5-component color
 struct ACMYK{T <: Fractional} <: AlphaColor{CMYK{T},T,5}
@@ -89,5 +94,5 @@ end
 # TODO: The following should be generated automatically
 ACMYK{T}(c, m, y, k, alpha=1) where {T} = ACMYK{T}(T(c), T(m), T(y), T(k), T(alpha))
 ACMYK(c::T, m::T, y::T, k::T, alpha::T=oneunit(T)) where {T} = ACMYK{T}(c, m, y, k, alpha)
-
+ACMYK{T}(col::CMYK{T}, alpha::T=oneunit(T)) where {T} = ACMYK{T}(col.c, col.m, col.y, col.k, alpha)
 end # module

--- a/test/error_hints.jl
+++ b/test/error_hints.jl
@@ -15,20 +15,8 @@ macro except_str(expr, err_type)
 end
 
 @testset "error hints" begin
-    @testset "zeros/ones" begin
+    @testset "ones" begin
         for T in (RGB, RGB{N0f8})
-            err_str = @except_str zero(T) MethodError
-            @test occursin(r"MethodError: no method matching zero\(::Type\{RGB.*\}", err_str)
-            @test occursin("You may need to `using ColorVectorSpace`.", err_str)
-
-            err_str = @except_str zero(T(1, 1, 1)) MethodError
-            @test occursin(r"MethodError: no method matching zero\(::RGB\{.*\}", err_str)
-            @test occursin("You may need to `using ColorVectorSpace`.", err_str)
-
-            err_str = @except_str zeros(T) MethodError
-            @test occursin(r"MethodError: no method matching zero\(::Type\{RGB.*\}", err_str)
-            @test occursin("You may need to `using ColorVectorSpace`.", err_str)
-
             err_str = @except_str one(T) MethodError
             @test occursin(r"MethodError: no method matching one\(::Type\{RGB.*\}", err_str)
             @test occursin("You may need to `using ColorVectorSpace`.", err_str)

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -594,25 +594,79 @@ end
 
 @testset "identities for Gray" begin
     @test oneunit(Gray{N0f8}) === Gray{N0f8}(1)
-    @test zero(Gray{N0f8}) === Gray{N0f8}(0)
-    @test oneunit(Gray) === Gray{N0f8}(1)
-    @test zero(Gray) === Gray{N0f8}(0)
+    @test zero(   Gray{N0f8}) === Gray{N0f8}(0)
+    @test @inferred(oneunit(Gray)) === Gray{N0f8}(1)
+    @test @inferred(zero(   Gray)) === Gray{N0f8}(0)
+    @test oneunit(Gray{Bool}) === Gray{Bool}(1)
+    @test zero(   Gray{Bool}) === Gray{Bool}(0)
 
-    @test_throws MethodError oneunit(Gray24)
-    @test_throws MethodError zero(Gray24)
-    @test_throws MethodError oneunit(AGray32)
-    @test_throws MethodError zero(AGray32)
-    @test_throws MethodError oneunit(AGray{N0f8})
-    @test_throws MethodError zero(AGray{N0f8})
-    @test_throws MethodError oneunit(GrayA{Float32})
-    @test_throws MethodError zero(GrayA{Float32})
+    @test oneunit(AGray{N0f8}) === AGray{N0f8}(1, 1)
+    @test zero(   AGray{N0f8}) === AGray{N0f8}(0, 0)
+    @test @inferred(oneunit(AGray)) === AGray{N0f8}(1, 1)
+    @test @inferred(zero(   AGray)) === AGray{N0f8}(0, 0)
+    @test oneunit(GrayA{Float32}) === GrayA{Float32}(1, 1)
+    @test zero(   GrayA{Float32}) === GrayA{Float32}(0, 0)
 
-    @test_throws MethodError oneunit(RGB{N0f8})
-    @test_throws MethodError zero(RGB{N0f8})
+    @test oneunit(Gray24) === Gray24(1)
+    @test zero(   Gray24) === Gray24(0)
+    @test oneunit(AGray32) === AGray32(1, 1)
+    @test zero(   AGray32) === AGray32(0, 0)
 
     g = Gray{Float32}(0.8)
-    @test_throws MethodError oneunit(g)
-    @test_throws MethodError zero(g)
+    @test oneunit(g) === Gray{Float32}(1)
+    @test zero(   g) === Gray{Float32}(0)
 
     @test_broken one(Gray{Float32}) * g == g * one(Gray{Float32}) == g
+end
+
+@testset "identities for RGB" begin
+    @test oneunit(RGB{N0f8}) === RGB{N0f8}(1, 1, 1)
+    @test zero(   RGB{N0f8}) === RGB{N0f8}(0, 0, 0)
+    @test @inferred(oneunit(RGB)) === RGB{N0f8}(1, 1, 1)
+    @test @inferred(zero(   RGB)) === RGB{N0f8}(0, 0, 0)
+
+    @test oneunit(ARGB{N0f8}) === ARGB{N0f8}(1, 1, 1, 1)
+    @test zero(   ARGB{N0f8}) === ARGB{N0f8}(0, 0, 0, 0)
+    @test @inferred(oneunit(ARGB)) === ARGB{N0f8}(1, 1, 1, 1)
+    @test @inferred(zero(   ARGB)) === ARGB{N0f8}(0, 0, 0, 0)
+    @test oneunit(RGBA{Float32}) === RGBA{Float32}(1, 1, 1, 1)
+    @test zero(   RGBA{Float32}) === RGBA{Float32}(0, 0, 0, 0)
+
+    @test oneunit(RGB24) === RGB24(1, 1, 1)
+    @test zero(   RGB24) === RGB24(0, 0, 0)
+    @test oneunit(ARGB32) === ARGB32(1, 1, 1, 1)
+    @test zero(   ARGB32) === ARGB32(0, 0, 0, 0)
+
+    c = RGB{Float32}(0.4, 0.5, 0.6)
+    @test oneunit(c) === RGB{Float32}(1, 1, 1)
+    @test zero(   c) === RGB{Float32}(0, 0, 0)
+end
+
+@testset "identities for other colors" begin
+    @test oneunit(XYZ{Float16}) === XYZ{Float16}(1, 1, 1)
+    @test zero(   XYZ{Float16}) === XYZ{Float16}(0, 0, 0)
+
+    @test @inferred(oneunit(LMS)) === LMS{Float32}(1, 1, 1)
+    @test @inferred(zero(   LMS)) === LMS{Float32}(0, 0, 0)
+
+    @test_throws MethodError oneunit(HSV{Float32})
+    @test zero(HSV{Float32}) === HSV{Float32}(0, 0, 0)
+
+    @test_throws MethodError oneunit(ALab{Float16})
+    @test zero(ALab{Float16}) === ALab{Float16}(0, 0, 0, 0)
+
+    @test_throws MethodError oneunit(LCHuvA{Float64})
+    @test zero(LCHuvA{Float64}) === LCHuvA{Float64}(0, 0, 0, 0)
+
+    @test_throws MethodError oneunit(C2{Float64})
+    @test zero(C2{Float64}) === C2{Float64}(0, 0)
+
+    @test_throws MethodError oneunit(C4{Float64})
+    @test zero(C4{Float64}) === C4{Float64}(0, 0, 0, 0)
+
+    @test oneunit(CMYK{N0f8}) === CMYK{N0f8}(1, 1, 1, 1)
+    @test zero(   CMYK{N0f8}) === CMYK{N0f8}(0, 0, 0, 0)
+
+    @test oneunit(ACMYK{N0f8}) === ACMYK{N0f8}(1, 1, 1, 1, 1)
+    @test zero(   ACMYK{N0f8}) === ACMYK{N0f8}(0, 0, 0, 0, 0)
 end


### PR DESCRIPTION
This is a part of PR #186.

This moves the `zero` and `oneunit` for  some of grays and rgbs that were defined in ColorVectorSpace to ColorTypes. (That is, this is a breaking change.)
For `zero`, a color with all components zero is considered reasonable as an additive identity in most color spaces. On the other hand, it is difficult to define `oneunit` in general. Therefore, `oneunit` is defined only for specific color spaces.

This does not change the definition of `one`.

Fixes #219