### PR TITLE
Add tests for constructors of `TransparentGray` and custom types

### DIFF
--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -818,7 +818,7 @@ end
 
     @test reinterpret(AGray32, 0xab121212) === AGray32(0.071, 0.671)
 
-    @test_throws MethodError reinterpret(UInt32, ARGB{N0f8}())
+    @test_throws ErrorException reinterpret(UInt32, ARGB{N0f8}(1, 0, 0))
     @test_throws ErrorException reinterpret(ARGB{N0f8}, 0x12345678)
 end
 

--- a/test/customtypes.jl
+++ b/test/customtypes.jl
@@ -5,7 +5,7 @@ using ColorTypes
 using ColorTypes.FixedPointNumbers
 
 export C2, C2A, C4, AC4
-export StrangeGray
+export StrangeGray, Cyanotype
 export AnaglyphColor, CMYK, ACMYK
 
 struct C2{T <: Real} <: Color{T,2}
@@ -40,7 +40,6 @@ ColorTypes.alphacolor(::Type{<:C4}) = AC4
 ColorTypes.eltype_default(::Type{<:AC4}) = Int16
 # TODO: The following should be generated automatically
 AC4{T}(c1, c2, c3, c4, alpha=1) where {T} = AC4{T}(T(c1), T(c2), T(c3), T(c4), T(alpha))
-
 
 struct StrangeGray{Something,T <: Integer} <: AbstractGray{Normed{T}}
     val::T


### PR DESCRIPTION
This includes the tests for PR #177.
This also includes tests for issue #230. However, I have not added tests for comparison with real numbers, as that is controversial (cf. https://github.com/JuliaGraphics/ColorTypes.jl/issues/230#issuecomment-801010654).