### PR TITLE
Improve `compN` for non-parametric `ColorAlpha` types

### DIFF
--- a/src/traits.jl
+++ b/src/traits.jl
@@ -60,6 +60,7 @@ hue(c::Union{C,AlphaColor{C},ColorAlpha{C}}) where {C<:Luv} =
 _comp(::Val{N}, c::Colorant) where N = getfield(c, N)
 _comp(::Val{N}, c::AlphaColor) where N = getfield(c, N + 1)
 _comp(::Val{N}, c::AlphaColorN{N}) where N = alpha(c)
+_comp(::Val{N}, c::ColorAlphaN{N}) where N = alpha(c)
 
 @noinline function _comp_error(c::ColorantN{N}, n::Int) where N
     io = IOBuffer()

--- a/test/customtypes.jl
+++ b/test/customtypes.jl
@@ -6,6 +6,7 @@ using ColorTypes.FixedPointNumbers
 
 export C2, C2A, C4, AC4
 export StrangeGray, Cyanotype
+export RGBA32
 export AnaglyphColor, CMYK, ACMYK
 
 struct C2{T <: Real} <: Color{T,2}
@@ -61,6 +62,20 @@ function Base.convert(::Type{Cout}, c::C) where {Cout <: AbstractRGB, T, C <: Cy
     b = 0.88 - 0.5 * c.value^2
     Cout(T(r), T(g), T(b))
 end
+
+# non-parametric color
+struct RGBA32 <: AbstractRGBA{RGB24, N0f8}
+    color::UInt32
+    RGBA32(c::UInt32, ::Type{Val{true}}) = new(c)
+end
+function RGBA32(r, g, b, alpha=1N0f8)
+    u32 = reinterpret(UInt32, ARGB32(r, g, b, alpha))
+    RGBA32((u32 << 0x8) | (u32 >> 0x18), Val{true})
+end
+ColorTypes.red(  c::RGBA32) = reinterpret(N0f8, (c.color >> 0x18) % UInt8)
+ColorTypes.green(c::RGBA32) = reinterpret(N0f8, (c.color >> 0x10) % UInt8)
+ColorTypes.blue( c::RGBA32) = reinterpret(N0f8, (c.color >> 0x08) % UInt8)
+ColorTypes.alpha(c::RGBA32) = reinterpret(N0f8, c.color % UInt8)
 
 # minimal type for testing 2-component color
 struct AnaglyphColor{T} <: Color{T,2} # not `TransparentGray`

--- a/test/show.jl
+++ b/test/show.jl
@@ -50,6 +50,8 @@ SP = VERSION >= v"1.6.0-DEV.771" ? " " : "" # JuliaLang/julia #37085
     show(iob, AGray32(0.8))
     @test String(take!(iob)) == "AGray32(0.8N0f8,1.0N0f8)"
 
+    show(iob, CustomTypes.RGBA32(0.4, 0.2, 0.8, 1.0))
+    @test String(take!(iob)) == "RGBA32(0.4N0f8,0.2N0f8,0.8N0f8,1.0N0f8)"
     show(iob, AnaglyphColor{Float32}(0.4, 0.2))
     @test String(take!(iob)) == "AnaglyphColor{Float32}(0.4f0,0.2f0)"
     show(iob, CMYK{Float64}(0.1, 0.2, 0.3, 0.4))

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -44,6 +44,13 @@ using .CustomTypes
         @test green(argb32) === 0.5N0f8
         @test blue(argb32)  === 0.0N0f8
     end
+    @testset "accessors for custom RGBA" begin
+        rgba32 = CustomTypes.RGBA32(1, 0.5, 0, 0.8)
+        @test red(rgba32)   === 1.0N0f8
+        @test green(rgba32) === 0.5N0f8
+        @test blue(rgba32)  === 0.0N0f8
+        @test alpha(rgba32) === 0.8N0f8
+    end
 
     @test_throws MethodError red(HSV(100, 0.6, 0.4))
 end
@@ -145,6 +152,11 @@ end
     @test comp5(ac4) === 0.5f0
     ct = Cyanotype{Float32}(0.8) # 1-component color but not a gray
     @test_broken comp1(ct) === 0.8f0
+    rgba32 = CustomTypes.RGBA32(1, 0.5, 0, 0.8)
+    @test comp1(rgba32) === 1N0f8
+    @test comp2(rgba32) === 0.5N0f8
+    @test comp3(rgba32) === 0N0f8
+    @test comp4(rgba32) === 0.8N0f8
 end
 
 @testset "color" begin


### PR DESCRIPTION
Since only `AGray32` and `ARGB32` are defined as non-parametric `TransparentColor` types, I did not notice this problem, but it would be better to specialize `compN` for `ColorAlpha` as well as `AlphaColor`.

This is not an urgent issue, since it can be solved by overloading `compN` by users or packages which define custom color types. Therefore, I will make this a part of v0.12 instead of v0.11, even though this is a non-breaking change as long as `alpha(c)` works.