### PR TITLE
Move `isfinite`, `isinf`, `isnan`, and `nan` from ColorVectorSpace

### DIFF
--- a/src/ColorTypes.jl
+++ b/src/ColorTypes.jl
@@ -6,7 +6,8 @@ using Base: @pure
 
 const Fractional = Union{AbstractFloat, FixedPoint}
 
-import Base: ==, <, isless, isapprox, hash, convert, eltype, length, show, oneunit, zero, reinterpret, getindex
+import Base: ==, <, isless, isapprox, isfinite, isinf, isnan, oneunit, zero,
+             hash, eltype, length, convert, reinterpret, show
 using Random
 import Random: rand
 

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -448,6 +448,27 @@ function ccolor(::Type{Cdest}, ::Type{Csrc}) where {Cdest<:Colorant, Csrc<:Union
     return C{Tdef}
 end
 
+isfinite(c::Colorant) = mapreducec(isfinite, &, true, c)
+isinf(c::Colorant) = mapreducec(isinf, |, false, c)
+isnan(c::Colorant) = mapreducec(isnan, |, false, c)
+
+"""
+    ColorTypes.nan(C)
+
+Return a color instance of the specified type in which all components are NaN.
+
+# Examples
+```jldoctest; setup = :(using ColorTypes)
+julia> ColorTypes.nan(RGB{Float32})
+RGB{Float32}(NaN32,NaN32,NaN32)
+
+julia> ColorTypes.nan(AHSV{Float64})
+AHSV{Float64}(NaN,NaN,NaN,NaN)
+```
+"""
+nan(::Type{T}) where {T<:AbstractFloat} = convert(T, NaN)
+nan(::Type{C}) where {T<:AbstractFloat, C<:Colorant{T}} = mapc(_ -> nan(T), zero(C))
+
 zero(::Type{C}) where {C<:ColorantN{1}} = C(0)
 zero(::Type{C}) where {C<:ColorantN{2}} = C(0, 0)
 zero(::Type{C}) where {C<:ColorantN{3}} = C(0, 0, 0)

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -592,6 +592,34 @@ end
     @test_throws MethodError ccolor(RGB, RGB{N0f8}(1,0,0))
 end
 
+@testset "isfinite/isinf/isnan" begin
+    cfff = RGB(1, 0, 0)
+    @test isfinite(cfff) && !isinf(cfff) && !isnan(cfff)
+    cfffn = ARGB(1, 0, 0, NaN32)
+    @test !isfinite(cfffn) && !isinf(cfffn) && isnan(cfffn)
+    cffif = HSVA(10, 0, Inf16, 0)
+    @test !isfinite(cffif) && isinf(cffif) && !isnan(cffif)
+    cni = GrayA(NaN, Inf)
+    @test !isfinite(cni) && isinf(cni) && isnan(cni)
+end
+
+@testset "nan" begin
+    @test ColorTypes.nan(Float32) === NaN32
+    @test ColorTypes.nan(Gray{Float32}) === Gray{Float32}(NaN32)
+    @test ColorTypes.nan(AGray{Float64}) === AGray{Float64}(NaN, NaN)
+    @test ColorTypes.nan(GrayA{Float16}) === GrayA{Float16}(NaN16, NaN16)
+    @test ColorTypes.nan(RGB{Float32}) === RGB{Float32}(NaN32, NaN32, NaN32)
+    @test ColorTypes.nan(ARGB{Float64}) === ARGB{Float64}(NaN, NaN, NaN, NaN)
+    @test ColorTypes.nan(RGBA{Float16}) === RGBA{Float16}(NaN16, NaN16, NaN16, NaN16)
+    @test ColorTypes.nan(HSV{Float32}) === HSV{Float32}(NaN32, NaN32, NaN32)
+    @test ColorTypes.nan(ALab{Float64}) === ALab{Float64}(NaN, NaN, NaN, NaN)
+    @test ColorTypes.nan(LuvA{Float16}) === LuvA{Float16}(NaN16, NaN16, NaN16, NaN16)
+
+    @test_throws MethodError ColorTypes.nan(RGB)
+    @test_throws MethodError ColorTypes.nan(ARGB32)
+    @test_throws MethodError ColorTypes.nan(Gray(1.0))
+end
+
 @testset "identities for Gray" begin
     @test oneunit(Gray{N0f8}) === Gray{N0f8}(1)
     @test zero(   Gray{N0f8}) === Gray{N0f8}(0)


### PR DESCRIPTION
This also generalizes `nan` to support any `Colorant` type. Note that this does not export `nan` to prevent name clashes.

see also: https://github.com/JuliaGraphics/ColorVectorSpace.jl/issues/75