### PR TITLE
Move `real(::Type{<:AbstractGray})` from ColorVectorSpace

### DIFF
--- a/src/ColorTypes.jl
+++ b/src/ColorTypes.jl
@@ -7,7 +7,7 @@ using Base: @pure
 const Fractional = Union{AbstractFloat, FixedPoint}
 
 import Base: ==, <, isless, isapprox, isfinite, isinf, isnan, oneunit, zero,
-             hash, eltype, length, convert, reinterpret, show
+             hash, eltype, length, real, convert, reinterpret, show
 using Random
 import Random: rand
 

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -113,7 +113,9 @@ convert(::Type{GrayA{T}}, x::Real) where {T} = GrayA{T}(x)
 convert(::Type{T}, x::Gray  ) where {T<:Real} = convert(T, x.val)
 convert(::Type{T}, x::Gray24) where {T<:Real} = convert(T, gray(x))
 (::Type{T})(x::AbstractGray)  where {T<:Real} = T(gray(x))
-Base.real(x::AbstractGray) = gray(x)
+
+real(x::AbstractGray) = gray(x)
+real(::Type{C}) where {C<:AbstractGray} = real(eltype(C))
 
 # Define some constructors that just call convert since the fallback constructor in Base
 # is removed in Julia 0.7

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -532,12 +532,14 @@ end
     @test Float32(Gray(0.6)) === 0.6f0
     @test float(Gray(0.6)) === 0.6
     @test real(Gray(0.6)) === 0.6
+    @test real(Gray{Float16}) === Float16
 
     @test convert(N0f8, Gray24(0.6)) === N0f8(0.6)
     @test convert(Float64, Gray24(0.6)) === 0.6
     @test Float32(Gray24(0.6)) === 0.6f0
     @test float(Gray24(0.6)) === 0.6
     @test real(Gray24(0.6)) === N0f8(0.6)
+    @test real(Gray24) === N0f8
 
     @test convert(Gray, 0.6) === Gray{Float64}(0.6)
     @test convert(Gray, 0.6f0) === Gray{Float32}(0.6)
@@ -562,6 +564,10 @@ end
     @test convert(AGray32, 0.6N0f8) === AGray32(0.6, 1)
     @test convert(AGray32, 0.6, 0.8) === AGray32(0.6, 0.8)
     @test convert(AGray32, 0, 1) === AGray32(0, 1)
+
+    @test_throws MethodError real(Gray) # should be a concrete type
+    @test_throws MethodError real(AGray(1.0))
+    @test_throws MethodError real(GrayA{Float32})
 
     @test_throws ColorTypeResolutionError convert(Colorant, 0.6)
     @test_throws ColorTypeResolutionError convert(Color, 0.6)


### PR DESCRIPTION
In practice, the method does not have much impact because of the fallback in `Base`. However, there are some differences as follows:

#### master w/o ColorVectorSpace
```julia
julia> real(Gray{Float32})
Float32

julia> real(Gray24)
ERROR: MethodError: no method matching zero(::Type{Gray24})

julia> real(Gray)
N0f8 (alias for Normed{UInt8, 8})
```

#### this PR (or w/ ColorVectorSpace)
```julia
julia> real(Gray{Float32})
Float32

julia> real(Gray24)
N0f8 (alias for Normed{UInt8, 8})

julia> real(Gray)
ERROR: MethodError: no method matching zero(::Type{Any})
```