### PR TITLE
Add error hints for color arithmetic

### DIFF
--- a/src/error_hints.jl
+++ b/src/error_hints.jl
@@ -1,3 +1,5 @@
+MathTypes{T,C} = Union{AbstractRGB{T},TransparentRGB{C,T},AbstractGray{T},TransparentGray{C,T}}
+
 # provided by https://github.com/JuliaLang/julia/pull/35094
 function register_hints()
     if isdefined(Base, :Experimental) && isdefined(Base.Experimental, :register_error_hint)
@@ -7,6 +9,14 @@ function register_hints()
             end
             if exc.f in (ones,) && argtypes[1] <: Type{<:AbstractRGB}
                 print(io, "\nYou may need to `using ColorVectorSpace`.")
+            end
+            # In theory we could list every function supported by ColorVectorSpace.
+            # This list of functions is far from comprehensive but may be enough to catch many users.
+            if exc.f in (+, -, *, /) && any(T->T<:MathTypes || T<:Type{<:MathTypes}, argtypes)
+                print(io, "\nMath on colors is deliberately undefined in ColorTypes, but see the ColorVectorSpace package.")
+            end
+            if (exc.f === *) && all(T->T<:MathTypes || T<:Type{<:MathTypes}, argtypes)
+                print(io, "\nYou may also need `⋅`, `⊙`, or `⊗`.")
             end
         end
     end

--- a/test/error_hints.jl
+++ b/test/error_hints.jl
@@ -30,4 +30,19 @@ end
             @test occursin("You may need to `using ColorVectorSpace`.", err_str)
         end
     end
+    @testset "Math" begin
+        gray = Gray(0.8)
+        rgb = RGB{Float32}(1, 0, 0)
+        err_str = @except_str gray + rgb MethodError
+        @test occursin("no method matching +(::Gray{Float64}, ::RGB{Float32})", err_str)
+        @test occursin("Math on colors is deliberately undefined in ColorTypes, but see the ColorVectorSpace package", err_str)
+
+        err_str = @except_str gray * rgb MethodError
+        @test occursin("no method matching *(::Gray{Float64}, ::RGB{Float32})", err_str)
+        @test occursin("Math on colors is deliberately undefined in ColorTypes, but see the ColorVectorSpace package", err_str)
+        @test occursin("You may also need `⋅`, `⊙`, or `⊗`.", err_str)
+
+        err_str = @except_str rgb * 0.5 MethodError
+        @test !occursin("You may also need `⋅`, `⊙`, or `⊗`.", err_str)
+    end
 end


### PR DESCRIPTION
This PR was separated from PR #186 via PR #243.
I changed the condition to suggest new multiplication operators to exclude real scaling cases like `RGB(1,1,1) * 0.3` in this PR.