### PR TITLE
Version 0.12.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,13 +1,13 @@
 name = "ColorTypes"
 uuid = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
-version = "0.11.0"
+version = "0.12.0"
 
 [deps]
 FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
-FixedPointNumbers = "0.5, 0.6, 0.7, 0.8"
+FixedPointNumbers = "0.6.1, 0.7, 0.8"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
#### TODO

- [x] Improve `compN` for non-parametric `ColorAlpha` types (PR #245)
- [x] Simplify display of colors (PR #206)
  - This can be a cause of failures in the testing of downstream packages, but I would rather merge it early to have time to fix the tests.
- [x] (Re-)define `one` for `Colorant` (PR #243)
- [x] Support `alpha(::Number)` (PR #177)
- [x] Use sampler-based Random API (PR #222)
- [x] Update `gamutmin`/`gamutmax` based on sRGB gamut (PR #254)
  - cf. issue #125
- [x] Make `AbstractGray` an abstract type instead of an alias (PR #252)
  - cf. issue #230
- [x] Generalize conversions from/to `Real` (PR #255)
- [x] Remove `eltype_ub` (PR #258)
  - cf. issue #257 
- [x] Redesign color constructors (PR #197)
- [x] Generalize conversions within the same base color
  - cf. issue #241
- [ ] Fix conversions from parametric colors to abstract colors
  - cf. `@test_broken`s in "test/conversions.jl"
- [x] Modify error messages in constructors (PR #256)
  - cf. issue #242
  - cf. https://github.com/JuliaGraphics/ColorTypes.jl/pull/187#discussion_r445370098
- [x] Add a "function" which returns a simple component iterator (PR #260)
  - cf. issue #190
  - In v0.12, it may be a private API. The enhancements will be made in ColorTypes v0.13.
- [x] Re-implement folding functions (e.g. `reducec`) with the component iterator (PR #263)
  - cf. issue #247
- [ ] Decide about the deprecation of `eltype` and `length`
  - cf. PR #184
- [ ] Define a new API to replace `eltype_default`
  - cf. issue #257
- [ ] Optimize `hue(c)` (PR #262)
  - cf. https://github.com/JuliaGraphics/Colors.jl/pull/495
- [ ] Update README.md (PR #250)
  - PR #250 will be separated into a number of PRs.


#### Version table

|ColorTypes       | v0.11.0  | v0.12.0    | v0.13.0 |
|:----------------|:---------|:-----------|:--------|
|FixedPointNumbers|(v0.5-0.8)| v0.6.1-0.8 | v0.9+   |
|Colors           |(v0.12.8) | v0.13.0    | v0.13.x?|
|ColorVectorSpace |(v0.9.4+) | v0.10.0    | v0.10.x?|
|ImageCore        |(v0.9.0+) | v0.9.x?    | ?       |
