### PR TITLE
Make `AbstractGray` an abstract type instead of an alias

### DIFF
--- a/src/ColorTypes.jl
+++ b/src/ColorTypes.jl
@@ -58,7 +58,7 @@ ColorTypes summary:
 ```
                           Colorant{T,N}
              Color{T,N}                    TransparentColor{C,T,N}
-     AbstractRGB{T}                  AlphaColor{C,T,N}  ColorAlpha{C,T,N}
+    AbstractRGB{T}  AbstractGray{T}    AlphaColor{C,T,N}  ColorAlpha{C,T,N}
 ```
 
 # Concrete types
@@ -71,7 +71,7 @@ ColorTypes summary:
 - Alpha-channel analogs in such as `ARGB` and `RGBA` for most of those
   types (with a few exceptions like `RGB24`, which has `ARGB32`)
 
-- Grayscale types `Gray` and `Gray24` (subtypes of `Color{T,1}`), and
+- Grayscale types `Gray` and `Gray24` (subtypes of `AbstractGray`), and
   the corresponding transparent types `AGray`, `GrayA`, and `AGray32`
 
 # Traits

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -46,7 +46,6 @@ function _promote_rule(::Type{C1}, ::Type{C2}) where {C1<:Colorant, C2<:Colorant
     et, alpha = _promote_et(C1, C2), _promote_alpha(C1, C2)
     Cp1, Cp2 = parametric_colorant(C1), parametric_colorant(C2)
     color = _promote_color(base_color_type(Cp1), base_color_type(Cp2))
-
     _with_et(C::UnionAll, et) = isconcretetype(et) ? C{et} : C
     if !isabstracttype(color)
         alpha <: Color && return _with_et(color, et)
@@ -112,10 +111,11 @@ convert(::Type{GrayA{T}}, x::Real) where {T} = GrayA{T}(x)
 
 convert(::Type{T}, x::Gray  ) where {T<:Real} = convert(T, x.val)
 convert(::Type{T}, x::Gray24) where {T<:Real} = convert(T, gray(x))
-(::Type{T})(x::AbstractGray)  where {T<:Real} = T(gray(x))
 
-real(x::AbstractGray) = gray(x)
-real(::Type{C}) where {C<:AbstractGray} = real(eltype(C))
+(::Type{T})(x::ColorantN{1})  where {T<:Real} = T(comp1(x))
+
+real(x::ColorantN{1}) = comp1(x)
+real(x::Type{<:ColorantN{1}}) = real(eltype(x))
 
 # Define some constructors that just call convert since the fallback constructor in Base
 # is removed in Julia 0.7

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -226,6 +226,7 @@ base_colorant_type(::Type{<:Number}) = Gray
 @pure basetype(@nospecialize(C)) = Base.typename(C).wrapper
 
 abstract_basetype(::Type{<:AbstractRGB}) = AbstractRGB
+abstract_basetype(::Type{<:AbstractGray}) = AbstractGray
 abstract_basetype(::Type{<:ColorN{N}}) where N = ColorN{N}
 abstract_basetype(::Type{<:Color}) = Color
 function abstract_basetype(::Type{TC}) where {TC<:TransparentColor}

--- a/src/types.jl
+++ b/src/types.jl
@@ -16,6 +16,17 @@ grayscale) with no transparency.
 abstract type Color{T, N} <: Colorant{T,N} end
 
 """
+`AbstractGray{T}` is an abstract supertype for gray types which corresponds to
+real numbers, where `0` means black and `1` means white.
+
+!!! compat "ColorTypes v0.12"
+    Prior to ColorTypes v0.12, `AbstractGray{T}` was the alias for `Color{T,1}`;
+    after ColorTypes v0.12, `Color{T,1}` does not necessarily correspond to the
+    black-gray-white colors.
+"""
+abstract type AbstractGray{T} <: Color{T,1} end
+
+"""
 `AbstractRGB{T}` is an abstract supertype for red/green/blue color types that
 can be constructed as `C(r, g, b)` and for which the elements can be
 extracted as `red(c)`, `green(c)`, `blue(c)`. You should *not* make
@@ -65,7 +76,6 @@ alpha channel comes last in the internal storage order.
 abstract type ColorAlpha{C<:Color,T,N} <: TransparentColor{C,T,N} end
 
 # These are types we'll dispatch on.
-AbstractGray{T}                    = Color{T,1}
 Color3{T}                          = Color{T,3}
 TransparentGray{C<:AbstractGray,T} = TransparentColor{C,T,2}
 Transparent3{C<:Color3,T}          = TransparentColor{C,T,4}

--- a/test/operations.jl
+++ b/test/operations.jl
@@ -133,6 +133,12 @@ end
     @test_throws MethodError GrayA(0.8, 0.4) <= GrayA(0.9, 0.4)
     @test_throws MethodError GrayA(0.9, 0.4) > GrayA(0.8, 0.4)
     @test_throws MethodError GrayA(0.9, 0.4) >= GrayA(0.8, 0.4)
+
+    # 1-component color but not a gray
+    @test_throws MethodError Cyanotype{Float32}(0.8) < Cyanotype{Float32}(0.9)
+    @test_throws MethodError isless(Cyanotype{Float32}(0.8), Cyanotype{Float32}(0.9))
+    @test_throws MethodError Cyanotype{Float64}(0.8) < Gray(0.9)
+    @test_throws MethodError Cyanotype{Float64}(0.8) < 0.9
 end
 
 @testset "rand" begin

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -152,7 +152,7 @@ end
     @test comp4(ac4) === 0.4f0
     @test comp5(ac4) === 0.5f0
     ct = Cyanotype{Float32}(0.8) # 1-component color but not a gray
-    @test_broken comp1(ct) === 0.8f0
+    @test comp1(ct) === 0.8f0
     rgba32 = CustomTypes.RGBA32(1, 0.5, 0, 0.8)
     @test comp1(rgba32) === 1N0f8
     @test comp2(rgba32) === 0.5N0f8


### PR DESCRIPTION
This classifies the properties of real numbers and the properties of the black-gray-white colors.

This should be mostly compatible for a single specific method, but may affect the multiple dispatch or ambiguity.

README.md will be updated with PR #250.

Closes #230