### PR TITLE
Update README.md

### DIFF
--- a/src/ColorTypes.jl
+++ b/src/ColorTypes.jl
@@ -54,14 +54,14 @@ Base.@deprecate_binding RGB4 RGBX
 """
 ColorTypes summary:
 
-Type hierarchy:
+# Type hierarchy
 ```
                           Colorant{T,N}
              Color{T,N}                    TransparentColor{C,T,N}
      AbstractRGB{T}                  AlphaColor{C,T,N}  ColorAlpha{C,T,N}
 ```
 
-Concrete types:
+# Concrete types
 - `RGB`, `BGR`, `XRGB`, `RGBX`, `RGB24` are all subtypes of `AbstractRGB`
 
 - `HSV`, `HSL`, `HSI`, `XYZ`, `xyY`, `Lab`, `LCHab`, `Luv`, `LCHuv`,
@@ -74,10 +74,12 @@ Concrete types:
 - Grayscale types `Gray` and `Gray24` (subtypes of `Color{T,1}`), and
   the corresponding transparent types `AGray`, `GrayA`, and `AGray32`
 
+# Traits
 - Trait functions `eltype`, `length`, `alphacolor`, `coloralpha`,
   `color_type`, `base_color_type`, `base_colorant_type`, `ccolor`
 
-- Getters `red`, `green`, `blue`, `alpha`, `gray`, `comp1`, `comp2`, `comp3`
+- Getters `red`, `green`, `blue`, `alpha`, `gray`,
+  `comp1`, `comp2`, `comp3`, `comp4`, `comp5`, `hue`, `chroma`
 
 Use `?` to get more information about specific types or functions.
 """ ColorTypes

--- a/src/types.jl
+++ b/src/types.jl
@@ -173,7 +173,7 @@ RGBX(r::T, g::T, b::T) where {T<:Fractional} = RGBX{T}(r, g, b)
 
 "`HSV` is the Hue-Saturation-Value colorspace."
 struct HSV{T<:AbstractFloat} <: Color{T,3}
-    h::T # Hue in [0,360)
+    h::T # Hue in [0,360]
     s::T # Saturation in [0,1]
     v::T # Value in [0,1]
 end
@@ -183,16 +183,16 @@ const HSB = HSV
 
 "`HSL` is the Hue-Saturation-Lightness colorspace."
 struct HSL{T<:AbstractFloat} <: Color{T,3}
-    h::T # Hue in [0,360)
+    h::T # Hue in [0,360]
     s::T # Saturation in [0,1]
     l::T # Lightness in [0,1]
 end
 
 "`HSI` is the Hue-Saturation-Intensity colorspace."
 struct HSI{T<:AbstractFloat} <: Color{T,3}
-    h::T
-    s::T
-    i::T
+    h::T # Hue in [0,360]
+    s::T # Saturation in [0,1]
+    i::T # Intensity in [0,1]
 end
 
 """
@@ -215,30 +215,30 @@ end
 
 "`Lab` is the CIELAB colorspace."
 struct Lab{T<:AbstractFloat} <: Color{T,3}
-    l::T # Luminance in approximately [0,100]
+    l::T # Lightness in [0,100]
     a::T # Red/Green
     b::T # Blue/Yellow
 end
 
 "`LCHab` is the Luminance-Chroma-Hue, Polar-Lab colorspace"
 struct LCHab{T<:AbstractFloat} <: Color{T,3}
-    l::T # Luminance in [0,100]
+    l::T # Lightness in [0,100]
     c::T # Chroma
-    h::T # Hue in [0,360)
+    h::T # Hue in [0,360]
 end
 
 "`Luv` is the CIELUV colorspace"
 struct Luv{T<:AbstractFloat} <: Color{T,3}
-    l::T # Luminance
+    l::T # Lightness in [0,100]
     u::T # Red/Green
     v::T # Blue/Yellow
 end
 
 "`LCHuv` is the Luminance-Chroma-Hue, Polar-Luv colorspace"
 struct LCHuv{T<:AbstractFloat} <: Color{T,3}
-    l::T # Luminance
+    l::T # Lightness in [0,100]
     c::T # Chroma
-    h::T # Hue
+    h::T # Hue in [0,360]
 end
 
 "`DIN99` is the (L99, a99, b99) adaptation of CIELAB"


### PR DESCRIPTION
This has been separated from PR #251.

This specifies that `360` is a valid hue in README.md、and adds the reference to `chroma` and `hue`, which were introduced in v0.8.1.
This also correct the meaning of "L" in Lab/Luv to "Lightness".

Closes #128