### PR TITLE
Modify error messages in constructors

### DIFF
--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -117,13 +117,6 @@ convert(::Type{T}, x::Gray24) where {T<:Real} = convert(T, gray(x))
 real(x::ColorantN{1}) = comp1(x)
 real(x::Type{<:ColorantN{1}}) = real(eltype(x))
 
-# Define some constructors that just call convert since the fallback constructor in Base
-# is removed in Julia 0.7
-# The parametric types are handled in @make_constructors and @make_alpha
-for t in (:ARGB32, :Gray24, :RGB24)
-    @eval $t(x) = convert($t, x)
-end
-
 # reinterpret
 for T in (RGB24, ARGB32, Gray24, AGray32)
     @eval begin

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -846,10 +846,14 @@ end
     @test Gray24(1) == 1
     @test !(Gray24(1) == 0x00ffffff)
     @test !(AGray32(1,0) == 0x00ffffff)
+    @test reinterpret(UInt32,   RGB24(0x000001)) === 0x00ffffff
+    @test reinterpret(UInt32,  ARGB32(0x000000)) === 0xff000000
+    @test reinterpret(UInt32,  Gray24(0x000000)) === 0x00000000
+    @test reinterpret(UInt32, AGray32(0x000001)) === 0xffffffff
     ret = @test_throws ArgumentError RGB24(0x00ffffff)
     @test occursin("Use `reinterpret(RGB24, 0x00ffffff)`", ret.value.msg)
     ret = @test_throws ArgumentError ARGB32(0x00ffffff)
-    @test_broken occursin("Use `reinterpret(ARGB32, 0x00ffffff)`", ret.value.msg)
+    @test occursin("Use `reinterpret(ARGB32, 0x00ffffff)`", ret.value.msg)
     ret = @test_throws ArgumentError Gray24(0x00ffffff)
     @test occursin("Use `reinterpret(Gray24, 0x00ffffff)`", ret.value.msg)
     ret = @test_throws ArgumentError AGray32(0x00ffffff)
@@ -857,7 +861,7 @@ end
     c = 0x123456
     ret = @test_throws ArgumentError RGB24(c >> 16 & 0xFF, c >> 8 & 0xFF, c & 0xFF)
     @test !occursin("Use `reinterpret(RGB24", ret.value.msg)
-    @test occursin("(0x00000012, 0x00000034, 0x00000056) do not lie", ret.value.msg)
+    @test occursin("(0x00000012, 0x00000034, 0x00000056) are integers", ret.value.msg)
     @test_throws ArgumentError RGB24[0x00000000,0x00808080]
     @test_throws ArgumentError RGB24[0x00000000,0x00808080,0x00ffffff]
     @test_throws ArgumentError RGB24[0x00000000,0x00808080,0x00ffffff,0x000000ff]


### PR DESCRIPTION
Closes #242

```
julia> RGB(255, 0, 0) # This PR
ERROR: ArgumentError: The components of RGB are normalized to the range 0-1,
  but (255, 0, 0) are integers in the range 0-255.
  Consider dividing your input values by 255, for example: RGB{N0f8}(255/255, 0/255, 0/255)
  The component type N0f8 is an 8-bit type representing 256 values from 0 to 1.
  You can also use `reinterpret(N0f8, x % UInt8)` to encode the input into N0f8.
  See the READMEs for FixedPointNumbers and ColorTypes for more information.
```