### PR TITLE
[WIP] Optimize `hue` and implement `polar_to_cartesian`

### DIFF
--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -77,6 +77,11 @@ function _precompile_()
         precompile(Tuple{typeof(green),C})
         precompile(Tuple{typeof(blue),C})
     end
+    for T in (Float32, Float64), C in (Lab, Luv)
+        precompile(Tuple{typeof(hue), C{T}})
+    end
+    precompile(Tuple{typeof(ColorTypes.polar_to_cartesian), Float32, Float32})
+    precompile(Tuple{typeof(ColorTypes.polar_to_cartesian), Float64, Float64})
     precompile(Tuple{typeof(eltype),Type{AbstractGray{T} where T<:Fractional}})
     precompile(Tuple{typeof(eltype),Type{AbstractRGB{T} where T<:Fractional}})
     # ccolor typically gets compiled as part of other things


### PR DESCRIPTION
This is a port of the improvements made in Colors.jl.
cf.  https://github.com/JuliaGraphics/Colors.jl/pull/495 and https://github.com/JuliaGraphics/Colors.jl/pull/510

I am slightly uncomfortable with the presence of specialized methods such as `atan360` and `sincos360` in ColorTypes.jl. However, the problem with Julia itself will not be fully resolved until the next LTS support ends, and I don't want to add new package dependencies.

This should be merged just before the release of ColorTypes v0.12.