### PR TITLE
Add `init` keyword support for `reducec` & `mapreducec`

### DIFF
--- a/src/operations.jl
+++ b/src/operations.jl
@@ -243,10 +243,11 @@ _same_colorspace(::Type{C}, ::Type{C}) where {C<:Colorant} = C
 
 """
     reducec(op, v0, c)
+    reducec(op, c; [init])
 
-Reduce across color channels of `c` with the binary operator
-`op`. `v0` is the neutral element used to initiate the reduction. For
-grayscale,
+Reduce across color channels of `c` with the binary operator `op`.
+`v0` or `init` is the neutral element used to initiate the reduction.
+For grayscale,
 
     reducec(op, v0, c::Gray) = op(v0, comp1(c))
 
@@ -255,16 +256,24 @@ whereas for RGB
     reducec(op, v0, c::RGB) = op(comp3(c), op(comp2(c), op(v0, comp1(c))))
 
 If `c` has an alpha channel, it is always the last one to be folded into the reduction.
+
+!!! compat "ColorTypes 0.12"
+    The keyword argument `init` and its omission using the default value require
+    ColorTypes v0.12 or later.
 """
 @inline reducec(op, v0, c::C) where {C <: Colorant} = reduce(op, Tuple(c); init=v0)
 @inline reducec(op, v0, x::Number) = op(v0, x)
+@inline reducec(op, c::C; kw...) where {C <: Colorant} = reduce(op, Tuple(c); kw...)
+@inline reducec(op, x::Number; kw...) = reduce(op, x; kw...)
 
 """
     mapreducec(f, op, v0, c)
+    mapreducec(f, op, c; [init])
 
 Reduce across color channels of `c` with the binary operator `op`,
-first applying `f` to each channel. `v0` is the neutral element used
-to initiate the reduction. For grayscale,
+first applying `f` to each channel.
+`v0` or `init` is the neutral element used to initiate the reduction.
+For grayscale,
 
     mapreducec(f, op, v0, c::Gray) = op(v0, f(comp1(c)))
 
@@ -273,6 +282,12 @@ whereas for RGB
     mapreducec(f, op, v0, c::RGB) = op(f(comp3(c)), op(f(comp2(c)), op(v0, f(comp1(c)))))
 
 If `c` has an alpha channel, it is always the last one to be folded into the reduction.
+
+!!! compat "ColorTypes 0.12"
+    The keyword argument `init` and its omission using the default value require
+    ColorTypes v0.12 or later.
 """
 @inline mapreducec(f, op, v0, c::C) where {C <: Colorant} = reduce(op, f.(comps(c)); init=v0)
 @inline mapreducec(f, op, v0, x::Number) = op(v0, f(x))
+@inline mapreducec(f, op, c::C; kw...) where {C <: Colorant} = reduce(op, f.(comps(c)); kw...)
+@inline mapreducec(f, op, x::Number; kw...) = reduce(op, f(x); kw...)

--- a/test/operations.jl
+++ b/test/operations.jl
@@ -260,6 +260,14 @@ end
     @test @inferred(reducec(&, true, true))
     @test !(@inferred(reducec(&, false, true)))
     @test !(@inferred(reducec(&, true, false)))
+
+    @test @inferred(reducec(+, Gray(0.3), init=0.5)) === 0.5 + 0.3
+    @test @inferred(reducec(+, AGray{N0f8}(0.3, 0.8))) === 0.3N0f8 + 0.8N0f8 # overflow
+    @test @inferred(reducec(*, RGB(0.3, 0.8, 0.5), init=0.5)) === ((0.5 * 0.3) * 0.8) * 0.5
+    @test @inferred(reducec(*, RGBA{N0f8}(0.3, 0.8, 0.5, 0.7))) === ((0.3N0f8 * 0.8N0f8) * 0.5N0f8) * 0.7N0f8
+
+    @test @inferred(reducec(max, 0.3, init=0.5)) === 0.5
+    @test @inferred(reducec(min, 0.3)) === 0.3
 end
 
 @testset "mapreducec" begin
@@ -283,6 +291,14 @@ end
     @test !(@inferred(mapreducec(x->!x, &, false, true)))
     @test @inferred(mapreducec(x->!x, &, true, false))
     @test !@inferred(mapreducec(x->!x, &, false, false))
+
+    @test @inferred(mapreducec(x->x^2, max, Gray(0.3), init=0.01)) === 0.3^2
+    @test @inferred(mapreducec(x->x^2, max, AGray{N0f8}(0.3, 0.8))) === N0f8(0.8)^2
+    @test @inferred(mapreducec(x->x^2, min, RGB(0.3, 0.8, 0.5), init=0.2)) === 0.3^2
+    @test @inferred(mapreducec(x->x^2, min, RGBA{N0f8}(0.3, 0.8, 0.5, 0.7))) === N0f8(0.3)^2
+
+    @test @inferred(mapreducec(x->x^2, +, 0.3, init=0.5)) === 0.5 + 0.3^2
+    @test @inferred(mapreducec(x->x^2, *, 0.3)) === 0.3^2
 end
 
 @testset "ones/zeros" begin


### PR DESCRIPTION
This also makes it possible to omit specifying the `init` value.

```julia
julia> rgb = rand(RGB, 1000, 1000);

julia> @btime reducec.(+, 0.2, rgb); # conventional
  1.746 ms (6 allocations: 7.63 MiB)

julia> @btime reducec.(+, rgb, init=0.2); # with `init`
  1.897 ms (13 allocations: 7.63 MiB)

julia> @btime reducec.(+, rgb); # omitting `init` (=`0.0`)
  1.883 ms (5 allocations: 7.63 MiB)
```

Closes #247