### PR TITLE
Simplify the 0-arg constructor and constructor-like functions

### DIFF
--- a/src/operations.jl
+++ b/src/operations.jl
@@ -145,11 +145,11 @@ function rand(r::AbstractRNG, ::SamplerType{C}) where {T, C<:Colorant{T}}
 end
 function rand(r::AbstractRNG, ::SamplerType{C}) where {T<:Rand01Type, C0<:AbstractGray{T},
                                                        C<:Union{C0, TransparentGray{C0, T}}}
-    mapc(_ -> rand(r, T), base_colorant_type(C)())
+    mapc(_ -> rand(r, T), C())
 end
 function rand(r::AbstractRNG, ::SamplerType{C}) where {T<:Rand01Type, C0<:AbstractRGB{T},
                                                        C<:Union{C0, TransparentRGB{C0, T}}}
-    mapc(_ -> rand(r, T), base_colorant_type(C)())
+    mapc(_ -> rand(r, T), C())
 end
 function rand(r::AbstractRNG, ::SamplerType{AGray32}) # Gray24 has little benefit of specialization.
     reinterpret(AGray32, (rand(r, UInt32) & 0xff0000ff) * 0x010101)

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -478,13 +478,9 @@ AHSV{Float64}(NaN, NaN, NaN, NaN)
 ```
 """
 nan(::Type{T}) where {T<:AbstractFloat} = convert(T, NaN)
-nan(::Type{C}) where {T<:AbstractFloat, C<:Colorant{T}} = mapc(_ -> nan(T), zero(C))
+nan(::Type{C}) where {T<:AbstractFloat, N, C<:Colorant{T, N}} = C(ntuple(_ -> nan(T), Val(N))...)
 
-zero(::Type{C}) where {C<:ColorantN{1}} = C(0)
-zero(::Type{C}) where {C<:ColorantN{2}} = C(0, 0)
-zero(::Type{C}) where {C<:ColorantN{3}} = C(0, 0, 0)
-zero(::Type{C}) where {C<:ColorantN{4}} = C(0, 0, 0, 0)
-zero(::Type{C}) where {C<:ColorantN{5}} = C(0, 0, 0, 0, 0)
+zero(::Type{C}) where {N, C<:ColorantN{N}} = C(ntuple(_ -> 0, Val(N))...)
 zero(c::Colorant) = zero(typeof(c))
 
 oneunit(::Type{C}) where {C<:Colorant} = throw_oneunit_error(C)

--- a/src/types.jl
+++ b/src/types.jl
@@ -512,12 +512,7 @@ _real(x::AbstractGray) = real(x)
 function (::Type{C})() where {N, C <: ColorantN{N}}
     d0 = zero(eltype_default(C))
     dx = C <: TransparentColor ? oneunit(eltype_default(C)) : d0
-    N == 1 && return _new_colorant(C, dx)
-    N == 2 && return _new_colorant(C, d0, dx)
-    N == 3 && return _new_colorant(C, d0, d0, dx)
-    N == 4 && return _new_colorant(C, d0, d0, d0, dx)
-    N == 5 && return _new_colorant(C, d0, d0, d0, d0, dx)
-    throw(MethodError(C, ()))
+    C(ntuple(_ -> d0, Val(N - 1))..., dx)
 end
 
 (::Type{C})(x         ) where {C <: Color    } = _new_colorant(C, x)


### PR DESCRIPTION
PR #197 made it unnecessary to use `base_colorant_type` (via `mapc`) in some cases.
This does not help to improve run-time performance, though.