### PR TITLE
disable precompilation due to package load time increase

### DIFF
--- a/src/ColorTypes.jl
+++ b/src/ColorTypes.jl
@@ -86,8 +86,9 @@ Use `?` to get more information about specific types or functions.
 
 if VERSION >= v"1.4.2" # work around https://github.com/JuliaLang/julia/issues/34121
     # ...and also requires https://github.com/JuliaLang/julia/pull/35378
-    include("precompile.jl")
-    _precompile_()
+    # Disabled for now, see https://github.com/JuliaGraphics/ColorTypes.jl/issues/269
+    #include("precompile.jl")
+    #_precompile_()
 end
 
 __init__() = register_hints()


### PR DESCRIPTION
Fixes https://github.com/JuliaGraphics/ColorTypes.jl/issues/269

I am not sure this was the conclusion of the discussion in there but I am putting up this in case it is ok.