### PR TITLE
Add Oklab perceptual color space

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,25 @@ struct LCHuv{T} <: Color{T,3}
 end
 ```
 
+### Oklab and LCHOklab
+
+A perceptual color space for image processing that preserves lightness upon grayscale conversion, maintains hue and lightness when increasing saturation and creates smooth and uniform looking transitions between colors, as well as it’s cylindrically reparametrised version.
+https://bottosson.github.io/posts/oklab/
+
+
+```julia
+struct Oklab{T} <: Color{T,3}
+    l::T # Lightness in [0,100]
+    a::T # Red/Green
+    b::T # Blue/Yellow
+end
+
+struct LCHOklab{T} <: Color{T,3}
+    l::T # Lightness in [0,100]
+    c::T # Chroma
+    h::T # Hue in [0,360]
+end
+```
 
 ### DIN99
 

--- a/README.md
+++ b/README.md
@@ -254,8 +254,7 @@ end
 
 ### Oklab and LCHOklab
 
-A perceptual color space for image processing that preserves lightness upon grayscale conversion, maintains hue and lightness when increasing saturation and creates smooth and uniform looking transitions between colors, as well as it’s cylindrically reparametrised version.
-https://bottosson.github.io/posts/oklab/
+A perceptual color space for image processing that preserves lightness upon grayscale conversion, maintains hue and lightness when increasing saturation and creates smooth and uniform looking transitions between colors, as well as it’s cylindrically reparametrised version. Based on work by [Björn Otteson](https://bottosson.github.io/posts/oklab/)
 
 
 ```julia

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ end
 
 ### Oklab and LCHOklab
 
-A perceptual color space for image processing that preserves lightness upon grayscale conversion, maintains hue and lightness when increasing saturation and creates smooth and uniform looking transitions between colors, as well as it’s cylindrically reparametrised version. Based on work by [Björn Otteson](https://bottosson.github.io/posts/oklab/)
+A perceptual color space for image processing that preserves lightness upon grayscale conversion, maintains hue and lightness when increasing saturation and creates smooth and uniform looking transitions between colors, as well as it’s cylindrically reparametrised version. Based on work by [Björn Otteson](https://bottosson.github.io/posts/oklab/).
 
 
 ```julia

--- a/src/ColorTypes.jl
+++ b/src/ColorTypes.jl
@@ -21,7 +21,7 @@ export AbstractAGray, AbstractGrayA, AbstractARGB, AbstractRGBA
 
 export RGB, BGR, XRGB, RGBX
 export HSV, HSB, HSL, HSI
-export XYZ, xyY, LMS, Lab, LCHab, Luv, LCHuv
+export XYZ, xyY, LMS, Lab, LCHab, Luv, LCHuv, Oklab, LCHOklab
 export DIN99, DIN99d, DIN99o
 export YIQ, YCbCr
 

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -45,13 +45,13 @@ gray(x::Number)  = convert(eltype(ccolor(Gray, typeof(x))), x)   # ensures it's 
 """
 chroma(c::Union{C,AlphaColor{C},ColorAlpha{C}}) where {C<:Union{Lab,Oklab,DIN99,DIN99o,DIN99d}} = sqrt(c.a^2 + c.b^2)
 chroma(c::Union{C,AlphaColor{C},ColorAlpha{C}}) where {C<:Luv} = sqrt(c.u^2 + c.v^2)
-chroma(c::Union{C,AlphaColor{C},ColorAlpha{C}}) where {C<:Union{LCHab,LCHuv}} = c.c
+chroma(c::Union{C,AlphaColor{C},ColorAlpha{C}}) where {C<:Union{LCHab,LCHuv, LCHOklab}} = c.c
 
 """
 `hue(c)` returns the hue in degrees. This function does not guarantee that the
 return value is in [0, 360].
 """
-hue(c::Union{C,AlphaColor{C},ColorAlpha{C}}) where {C<:Union{HSV,HSL,HSI,LCHab,LCHuv}} = c.h
+hue(c::Union{C,AlphaColor{C},ColorAlpha{C}}) where {C<:Union{HSV,HSL,HSI,LCHab,LCHuv, LCHOklab}} = c.h
 hue(c::Union{C,AlphaColor{C},ColorAlpha{C}}) where {C<:Union{Lab,Oklab,DIN99,DIN99o,DIN99d}} =
     (h = atand(c.b, c.a); h < 0 ? h + 360 : h)
 hue(c::Union{C,AlphaColor{C},ColorAlpha{C}}) where {C<:Luv} =

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -43,7 +43,7 @@ gray(x::Number)  = convert(eltype(ccolor(Gray, typeof(x))), x)   # ensures it's 
     because their definitions of *chroma* are not clear. Colorfulness, chroma
     and saturation are defined as distinct aspects by the CIE.
 """
-chroma(c::Union{C,AlphaColor{C},ColorAlpha{C}}) where {C<:Union{Lab,DIN99,DIN99o,DIN99d}} = sqrt(c.a^2 + c.b^2)
+chroma(c::Union{C,AlphaColor{C},ColorAlpha{C}}) where {C<:Union{Lab,Oklab,DIN99,DIN99o,DIN99d}} = sqrt(c.a^2 + c.b^2)
 chroma(c::Union{C,AlphaColor{C},ColorAlpha{C}}) where {C<:Luv} = sqrt(c.u^2 + c.v^2)
 chroma(c::Union{C,AlphaColor{C},ColorAlpha{C}}) where {C<:Union{LCHab,LCHuv}} = c.c
 
@@ -52,7 +52,7 @@ chroma(c::Union{C,AlphaColor{C},ColorAlpha{C}}) where {C<:Union{LCHab,LCHuv}} = 
 return value is in [0, 360].
 """
 hue(c::Union{C,AlphaColor{C},ColorAlpha{C}}) where {C<:Union{HSV,HSL,HSI,LCHab,LCHuv}} = c.h
-hue(c::Union{C,AlphaColor{C},ColorAlpha{C}}) where {C<:Union{Lab,DIN99,DIN99o,DIN99d}} =
+hue(c::Union{C,AlphaColor{C},ColorAlpha{C}}) where {C<:Union{Lab,Oklab,DIN99,DIN99o,DIN99d}} =
     (h = atand(c.b, c.a); h < 0 ? h + 360 : h)
 hue(c::Union{C,AlphaColor{C},ColorAlpha{C}}) where {C<:Luv} =
     (h = atand(c.v, c.u); h < 0 ? h + 360 : h)

--- a/src/types.jl
+++ b/src/types.jl
@@ -226,6 +226,20 @@ struct LCHuv{T<:AbstractFloat} <: Color{T,3}
     h::T # Hue in [0,360]
 end
 
+"`Oklab` is the Oklab colorspace."
+struct Oklab{T<:AbstractFloat} <: Color{T,3}
+    l::T # Lightness in [0,100]
+    a::T # Red/Green
+    b::T # Blue/Yellow
+end
+
+"`LCHOklab` is the Luminance-Chroma-Hue, Polar-Oklab colorspace"
+struct LCHOklab{T<:AbstractFloat} <: Color{T,3}
+    l::T # Lightness in [0,100]
+    c::T # Chroma
+    h::T # Hue in [0,360]
+end
+
 "`DIN99` is the (L99, a99, b99) adaptation of CIELAB"
 struct DIN99{T<:AbstractFloat} <: Color{T,3}
     l::T # L99
@@ -482,9 +496,11 @@ for (C, acol, cola) in [(DIN99d, :ADIN99d, :DIN99dA),
                         (HSV, :AHSV, :HSVA),
                         (LCHab, :ALCHab, :LCHabA),
                         (LCHuv, :ALCHuv, :LCHuvA),
+                        (LCHOklab, :ALCHOklab, :LCHOklabA),
                         (LMS, :ALMS, :LMSA),
                         (Lab, :ALab, :LabA),
                         (Luv, :ALuv, :LuvA),
+                        (Oklab, :AOklab, :OklabA),
                         (XYZ, :AXYZ, :XYZA),
                         (YCbCr, :AYCbCr, :YCbCrA),
                         (YIQ, :AYIQ, :YIQA),


### PR DESCRIPTION
Implements the Oklab color space as described here: https://bottosson.github.io/posts/oklab/

Adds and exports the type.
Adds Oklab and LCHOklab to the chroma and hue trait accessor functions.
Adds description to the readme.

This is my first contribution to Julia, and any software package in general so help with any oversights would be greatly appreciated. (Am I missing tests for example? They weren’t mentioned in the guidelines of how to extend color types.)