### PR TITLE
Support `isequal`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ColorTypes"
 uuid = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
-version = "0.11.0"
+version = "0.11.1"
 
 [deps]
 FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -54,6 +54,13 @@ end
 ==(x::Number, y::AbstractGray) = x == gray(y)
 ==(x::AbstractGray, y::Number) = ==(y, x)
 
+function Base.isequal(a::ColorantN{N}, b::ColorantN{N}) where {N}
+    _is_same_colorspace(a, b) || return false
+    all(isequal.(comps(a), comps(b)))
+end
+Base.isequal(x::Number, y::AbstractGray) = isequal(x, gray(y))
+Base.isequal(x::AbstractGray, y::Number) = isequal(y, x)
+
 
 function isapprox(a::ColorantN{N}, b::ColorantN{N}; kwargs...) where {N}
     _is_same_colorspace(a, b) || return false

--- a/test/operations.jl
+++ b/test/operations.jl
@@ -39,6 +39,8 @@ end
     for C in unique(vcat(Cp3, coloralpha.(Cp3), alphacolor.(Cp3)))
         @test C{Float64}(1,0,0) == C{Float32}(1,0,0)
         @test C{Float32}(1,0,0) != C{Float32}(1,0,0.1)
+        @test isequal(C{Float64}(1,0,0), C{Float32}(1,0,0))
+        @test !isequal(C{Float32}(1,0,0), C{Float32}(1,0,0.1))
     end
 
     for (a, b) in ((Gray(1.0), Gray(1)),
@@ -49,6 +51,7 @@ end
         local a, b
         @test a !== b
         @test a == b
+        @test isequal(a, b)
         @test hash(a) == hash(b)
     end
     for (a, b) in ((RGB(1, 0.5, 0), RGBA(1, 0.5, 0, 0.9)),
@@ -57,7 +60,16 @@ end
                    (Lab(70, 0, 60), LCHab(70, 60, 90)))
         local a, b
         @test a != b
+        @test !isequal(a, b)
         @test hash(a) != hash(b)
+    end
+    for (a, b) in ((RGB(1.0, 0.5, NaN), RGB(1.0, 0.5, NaN)),
+                   (Gray(NaN32), Gray(NaN)),
+                   (Gray(NaN), NaN))
+        @test a != b
+        @test b != a
+        @test isequal(a, b)
+        @test isequal(b, a)
     end
     # It's not obvious whether we want these to compare as equal, but
     # whatever happens, you want hashing and equality-testing to yield the


### PR DESCRIPTION
Formerly we fell back to `==`, but this does not do the right thing
for `NaN` components.