### PR TITLE
ColorTypes v0.11.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ColorTypes"
 uuid = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
-version = "0.11.0"
+version = "0.11.2"
 
 [deps]
 FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ColorTypes"
 uuid = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
-version = "0.11.1"
+version = "0.11.0"
 
 [deps]
 FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"

--- a/README.md
+++ b/README.md
@@ -423,4 +423,4 @@ In most cases, adding a new color space is quite straightforward:
 In special cases, there may be other considerations:
 - For `AbstractRGB`/`AbstractGray` types, `0` means "black" and `1` means
   "saturated."
-- If your type has extra fields, check the "Generated code" section of `types.jl` carefully. You may need to define a `colorfields` function and/or call `@make_alpha` manually.
+- If your type has extra fields, check the "Generated code" section of `types.jl` carefully. You may need to define a `colorfields` function and/or call `@make_constructors` or `@make_alpha` manually.

--- a/README.md
+++ b/README.md
@@ -43,12 +43,12 @@ Here is the type hierarchy used in ColorTypes:
 - To support generic programming, `TransparentColor` constructors
   always take the alpha channel last, independent of their internal
   storage order. That is, one uses
-  ```julia
-  RGBA(red, green, blue, alpha)
-  ARGB(red, green, blue, alpha) # note alpha is last
-  RGBA(RGB(red, green, blue), alpha)
-  ARGB(RGB(red, green, blue), alpha)
-  ```
+```julia
+RGBA(red, green, blue, alpha)
+RGBA(RGB(red, green, blue), alpha)
+ARGB(red, green, blue, alpha)       # note alpha is last
+ARGB(RGB(red, green, blue), alpha)
+```
   This way you can write code with a generic `C<:Colorant` type and
   not worry about the proper order for supplying arguments to the
   constructor.  See the [traits section](#traits) for some useful
@@ -86,7 +86,7 @@ and `RGB(255, 0, 0)` throws an error.
 
 The analogous `BGR` type is defined as
 
-```julia
+```jl
 struct BGR{T} <: AbstractRGB{T}
     b::T
     g::T
@@ -104,30 +104,22 @@ one extra ("invisible") padding element; when the element type is
 `N0f8`, these have favorable memory alignment for interfacing with
 libraries like OpenGL.
 
-Finally, one may encode an RGB or ARGB color as 8-bit values packed into a
+Finally, one may represent an RGB color as 8-bit values packed into a
 32-bit integer:
 
 ```julia
 struct RGB24 <: AbstractRGB{N0f8}
     color::UInt32
 end
-
-struct ARGB32 <: AbstractARGB{N0f8}
-    color::UInt32
-end
 ```
 
-The storage order is `0xAARRGGBB`, where `RR` means the red channel, `GG` means
-the green, and `BB` means the blue.
-`AA` means the alpha and is ignored for `RGB24`.
-Note that on little-endian machines, contrary to the names, they are stored in
-memory in BGRA order.
-
-These types can be constructed as `RGB24(1.0, 0.5, 0.0)`, not as
-`RGB24(0xff, 0x80, 0x00)` (for an orange `#ff8000`).
-However, since these types have no fields named `r`, `g`, `b`, it is better to
-extract values from an `AbstractRGB`/`TransparentRGB` object `c` using `red(c)`,
-`green(c)`, `blue(c)`.
+The storage order is `0xAARRGGBB`, where `RR` means the red channel,
+`GG` means the green, and `BB` means the blue.  `AA` is ignored for
+`RGB24`; there is also an `ARGB32`, for which that byte represents
+alpha. Note that this type can also be constructed as
+`RGB24(0.8,0.5,0.2)`. However, since this type has no fields named
+`r`, `g`, `b`, it is better to extract values from `AbstractRGB`
+objects using `red(c)`, `green(c)`, `blue(c)`.
 
 
 ### HSV
@@ -138,15 +130,15 @@ sometimes called "HSB" for Hue-Saturation-Brightness.
 
 ```julia
 struct HSV{T} <: Color{T,3}
-    h::T # Hue in [0,360]
+    h::T # Hue in [0,360)
     s::T # Saturation in [0,1]
     v::T # Value in [0,1]
 end
 ```
 
-For HSV (and all remaining color types), `T` must be of `AbstractFloat` type.
-Due to [rounding errors](https://docs.julialang.org/en/v1/base/math/#Base.mod)
-in floating point arithmetic, `360` should also be handled as a valid hue.
+For HSV (and all remaining color types), `T` must be of
+`AbstractFloat` type, since the values range beyond what can be
+represented with most `FixedPoint` types.
 
 ### HSL
 
@@ -155,7 +147,7 @@ common projection of RGB to cylindrical coordinates.
 
 ```julia
 struct HSL{T} <: Color{T,3}
-    h::T # Hue in [0,360]
+    h::T # Hue in [0,360)
     s::T # Saturation in [0,1]
     l::T # Lightness in [0,1]
 end
@@ -168,9 +160,9 @@ in computer vision.
 
 ```julia
 struct HSI{T} <: Color{T,3}
-    h::T # Hue in [0,360]
-    s::T # Saturation in [0,1]
-    i::T # Intensity in [0,1]
+    h::T
+    s::T
+    i::T
 end
 ```
 
@@ -211,11 +203,11 @@ end
 ### Lab
 
 A perceptually uniform colorspace standardized by the CIE in 1976. See
-also Luv, the associated colorspace standardized the same year.
+also LUV, the associated colorspace standardized the same year.
 
 ```julia
 struct Lab{T} <: Color{T,3}
-    l::T # Lightness in [0,100]
+    l::T # Luminance in approximately [0,100]
     a::T # Red/Green
     b::T # Blue/Yellow
 end
@@ -224,31 +216,39 @@ end
 ### Luv
 
 A perceptually uniform colorspace standardized by the CIE in 1976. See
-also Lab, a similar colorspace standardized the same year.
+also LAB, a similar colorspace standardized the same year.
 
 ```julia
 struct Luv{T} <: Color{T,3}
-    l::T # Lightness in [0,100]
+    l::T # Luminance
     u::T # Red/Green
     v::T # Blue/Yellow
 end
 ```
 
-### LCHab and LCHuv
 
-The Lab/Luv colorspace reparameterized using cylindrical coordinates.
+### LCHab
+
+The LAB colorspace reparameterized using cylindrical coordinates.
 
 ```julia
 struct LCHab{T} <: Color{T,3}
-    l::T # Lightness in [0,100]
+    l::T # Luminance in [0,100]
     c::T # Chroma
-    h::T # Hue in [0,360]
+    h::T # Hue in [0,360)
 end
+```
 
+
+### LCHuv
+
+The LUV colorspace reparameterized using cylindrical coordinates.
+
+```julia
 struct LCHuv{T} <: Color{T,3}
-    l::T # Lightness in [0,100]
+    l::T # Luminance
     c::T # Chroma
-    h::T # Hue in [0,360]
+    h::T # Hue
 end
 ```
 
@@ -266,18 +266,29 @@ end
 ```
 
 
-### DIN99d and DIN99o
+### DIN99d
 
-The DIN99d and DIN99o are revised version of the DIN99.
-These colorspaces are mainly used to calculate color differences.
+The DIN99d uniform colorspace is an improvement on the DIN99 color
+space that adds a correction to the X tristimulus value in order to
+emulate the rotation term present in the DeltaE2000 equation.
 
 ```julia
 struct DIN99d{T} <: Color{T,3}
     l::T # L99d (Lightness)
-    a::T # a99d (Red/Green)
-    b::T # b99d (Blue/Yellow)
+    a::T # a99d (Reddish/Greenish)
+    b::T # b99d (Bluish/Yellowish)
 end
+```
 
+
+### DIN99o
+
+Revised version of the DIN99 uniform colorspace with modified
+coefficients for an improved metric.  Similar to DIN99d X correction
+and the DeltaE2000 rotation term, DIN99o achieves comparable results
+by optimized `a*/b*` rotation and chroma compression terms.
+
+```julia
 struct DIN99o{T} <: Color{T,3}
     l::T # L99o (Lightness)
     a::T # a99o (Red/Green)
@@ -303,7 +314,7 @@ end
 
 Like `XYZ`, `LMS` is a linear color space.
 
-### YIQ
+### YIQ (NTSC)
 
 A color-encoding format used by the NTSC broadcast standard.
 
@@ -319,7 +330,7 @@ end
 
 A color-encoding format common in video and digital photography.
 
-```julia
+```jl
 struct YCbCr{T} <: Color{T,3}
     y::T
     cb::T
@@ -331,10 +342,8 @@ end
 
 ### Gray
 
-`Gray` is a simple wrapper around a real number, where `0` means black and `1`
-means white.
-
-```julia
+`Gray` is a simple wrapper around a number:
+```jl
 struct Gray{T} <: AbstractGray{T}
     val::T
 end
@@ -349,13 +358,13 @@ types, `AGray` and `GrayA`.
 ### Gray24 and AGray32
 
 `Gray24` is a grayscale value encoded as a `UInt32`:
-```julia
+```jl
 struct Gray24 <: AbstractGray{N0f8}
     color::UInt32
 end
 ```
 
-The storage format is `0xAAIIIIII`, where each `II` (intensity) pair
+The storage format is `0xAAIIIIII`, where each `II` pair (I=intensity)
 must be identical.  The `AA` is ignored, but in the corresponding
 `AGray32` type it encodes alpha.
 
@@ -390,15 +399,11 @@ greater detail); just type `?ccolor` at the REPL.
 - `red`, `green`, `blue` extract channels from `AbstractRGB` types;
   `gray` extracts the intensity from a grayscale object
 
-- `alpha` extracts the alpha channel from any `Colorant` object
+- `alpha` extracts the alpha channel from any `Color` object
   (returning 1 if there is no alpha channel)
 
 - `comp1`, `comp2`, `comp3`, `comp4` and `comp5` extract color components in the
   order expected by the constructor
-
-- `hue` extracts the hue from an `HSV`-like or `Lab`-like object
-
-- `chroma` extracts the chroma (not the saturation) from a `Lab`-like object
 
 ### Functions
 
@@ -421,6 +426,5 @@ In most cases, adding a new color space is quite straightforward:
 - In the Colors package, add [conversions](https://github.com/JuliaGraphics/Colors.jl/blob/master/src/conversions.jl) to and from your new colorspace.
 
 In special cases, there may be other considerations:
-- For `AbstractRGB`/`AbstractGray` types, `0` means "black" and `1` means
-  "saturated."
+- For RGB-related types, 0 means "black" and 1 means "saturated." If your type has unusual numeric interpretation, you may need to add a new number type to [FixedPointNumbers](https://github.com/JeffBezanson/FixedPointNumbers.jl) and set up appropriate `eltype_default` and `eltype_ub` traits.
 - If your type has extra fields, check the "Generated code" section of `types.jl` carefully. You may need to define a `colorfields` function and/or call `@make_constructors` or `@make_alpha` manually.

--- a/src/ColorTypes.jl
+++ b/src/ColorTypes.jl
@@ -54,14 +54,14 @@ Base.@deprecate_binding RGB4 RGBX
 """
 ColorTypes summary:
 
-# Type hierarchy
+Type hierarchy:
 ```
                           Colorant{T,N}
              Color{T,N}                    TransparentColor{C,T,N}
      AbstractRGB{T}                  AlphaColor{C,T,N}  ColorAlpha{C,T,N}
 ```
 
-# Concrete types
+Concrete types:
 - `RGB`, `BGR`, `XRGB`, `RGBX`, `RGB24` are all subtypes of `AbstractRGB`
 
 - `HSV`, `HSL`, `HSI`, `XYZ`, `xyY`, `Lab`, `LCHab`, `Luv`, `LCHuv`,
@@ -74,12 +74,10 @@ ColorTypes summary:
 - Grayscale types `Gray` and `Gray24` (subtypes of `Color{T,1}`), and
   the corresponding transparent types `AGray`, `GrayA`, and `AGray32`
 
-# Traits
 - Trait functions `eltype`, `length`, `alphacolor`, `coloralpha`,
   `color_type`, `base_color_type`, `base_colorant_type`, `ccolor`
 
-- Getters `red`, `green`, `blue`, `alpha`, `gray`,
-  `comp1`, `comp2`, `comp3`, `comp4`, `comp5`, `hue`, `chroma`
+- Getters `red`, `green`, `blue`, `alpha`, `gray`, `comp1`, `comp2`, `comp3`
 
 Use `?` to get more information about specific types or functions.
 """ ColorTypes

--- a/src/ColorTypes.jl
+++ b/src/ColorTypes.jl
@@ -58,7 +58,7 @@ ColorTypes summary:
 ```
                           Colorant{T,N}
              Color{T,N}                    TransparentColor{C,T,N}
-    AbstractRGB{T}  AbstractGray{T}    AlphaColor{C,T,N}  ColorAlpha{C,T,N}
+     AbstractRGB{T}                  AlphaColor{C,T,N}  ColorAlpha{C,T,N}
 ```
 
 # Concrete types
@@ -71,7 +71,7 @@ ColorTypes summary:
 - Alpha-channel analogs in such as `ARGB` and `RGBA` for most of those
   types (with a few exceptions like `RGB24`, which has `ARGB32`)
 
-- Grayscale types `Gray` and `Gray24` (subtypes of `AbstractGray`), and
+- Grayscale types `Gray` and `Gray24` (subtypes of `Color{T,1}`), and
   the corresponding transparent types `AGray`, `GrayA`, and `AGray32`
 
 # Traits

--- a/src/ColorTypes.jl
+++ b/src/ColorTypes.jl
@@ -8,8 +8,8 @@ const Fractional = Union{AbstractFloat, FixedPoint}
 
 import Base: ==, <, isless, isapprox, isfinite, isinf, isnan, one, oneunit, zero,
              hash, eltype, length, real, convert, reinterpret, show
-using Random: Random, AbstractRNG, SamplerType
-import Random: rand, rand!
+using Random
+import Random: rand
 
 ## Types
 export Fractional

--- a/src/ColorTypes.jl
+++ b/src/ColorTypes.jl
@@ -6,7 +6,7 @@ using Base: @pure
 
 const Fractional = Union{AbstractFloat, FixedPoint}
 
-import Base: ==, <, isless, isapprox, isfinite, isinf, isnan, one, oneunit, zero,
+import Base: ==, <, isless, isapprox, isfinite, isinf, isnan, oneunit, zero,
              hash, eltype, length, real, convert, reinterpret, show
 using Random
 import Random: rand

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -78,8 +78,8 @@ convert(::Type{C}, c::Color, alpha) where {C<:TransparentColor} = cconvert(ccolo
 cconvert(::Type{C}, c::Color, alpha) where {C<:TransparentColor} =_convert(C, base_color_type(C), base_color_type(c), c, alpha)
 
 # Fallback definitions that print nice error messages
-_convert(C::Type, ::Any, ::Any, c) = error("No conversion of ", c, " to ", C, " has been defined")
-_convert(C::Type, C1::Any, C2::Any, c, alpha) = error("No conversion of (", c, ",alpha=$alpha) to ", C, " with consistency-types $C1 and $C2 has been defined")
+_convert(::Type{C}, ::Any, ::Any, c) where {C} = error("No conversion of ", c, " to ", C, " has been defined")
+_convert(::Type{C}, C1::Any, C2::Any, c, alpha) where {C} = error("No conversion of (", c, ",alpha=$alpha) to ", C, " with consistency-types $C1 and $C2 has been defined")
 
 # Any AbstractRGB types can be interconverted
 _convert(::Type{Cout}, ::Type{C1}, ::Type{C2}, c) where {Cout<:AbstractRGB,C1<:AbstractRGB,C2<:AbstractRGB} = Cout(red(c), green(c), blue(c))
@@ -87,13 +87,8 @@ _convert(::Type{A}, ::Type{C1}, ::Type{C2}, c, alpha=alpha(c)) where {A<:Transpa
 
 # Implementations for when the base color type is not changing
 # These might strip/add transparency, however
-function _convert(::Type{Cout}, ::Type{C1}, ::Type{C1}, c) where {Cout<:Color, C1<:Color}
-    Cout(comps(color(c))...)
-end
-function _convert(::Type{Cout}, ::Type{C1}, ::Type{C1}, c,
-                  alpha=alpha(c)) where {Cout<:TransparentColor, C1<:Color}
-    Cout(comps(color(c))..., alpha)
-end
+_convert(::Type{Cout}, ::Type{Ccmp}, ::Type{Ccmp}, c) where {Cout<:Color3,Ccmp<:Color3} = Cout(comp1(c), comp2(c), comp3(c))
+_convert(::Type{A}, ::Type{Ccmp}, ::Type{Ccmp}, c, alpha=alpha(c)) where {A<:Transparent3,Ccmp<:Color3} = A(comp1(c), comp2(c), comp3(c), alpha)
 
 # Grayscale
 _convert(::Type{Cout}, ::Type{C1}, ::Type{C2}, c) where {Cout<:AbstractGray,C1<:AbstractGray,C2<:AbstractGray} = Cout(gray(c))

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -110,6 +110,13 @@ convert(::Type{T}, x::ColorantN{1}) where {T<:Real} = convert(T, comp1(x))
 real(x::ColorantN{1}) = comp1(x)
 real(x::Type{<:ColorantN{1}}) = real(eltype(x))
 
+# Define some constructors that just call convert since the fallback constructor in Base
+# is removed in Julia 0.7
+# The parametric types are handled in @make_constructors and @make_alpha
+for t in (:ARGB32, :Gray24, :RGB24)
+    @eval $t(x) = convert($t, x)
+end
+
 # reinterpret
 for T in (RGB24, ARGB32, Gray24, AGray32)
     @eval begin

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -76,6 +76,7 @@ cconvert(::Type{C}, c) where {C} = _convert(C, base_color_type(C), base_color_ty
 
 convert(::Type{C}, c::Color, alpha) where {C<:TransparentColor} = cconvert(ccolor(C, typeof(c)), c, alpha)
 cconvert(::Type{C}, c::Color, alpha) where {C<:TransparentColor} =_convert(C, base_color_type(C), base_color_type(c), c, alpha)
+cconvert(::Type{ARGB32}, c::AbstractRGB, alpha) = ARGB32(c, alpha) # optimization for speed
 
 # Fallback definitions that print nice error messages
 _convert(::Type{C}, ::Any, ::Any, c) where {C} = error("No conversion of ", c, " to ", C, " has been defined")
@@ -86,7 +87,7 @@ _convert(::Type{Cout}, ::Type{C1}, ::Type{C2}, c) where {Cout<:AbstractRGB,C1<:A
 _convert(::Type{A}, ::Type{C1}, ::Type{C2}, c, alpha=alpha(c)) where {A<:TransparentRGB,C1<:AbstractRGB,C2<:AbstractRGB} = A(red(c), green(c), blue(c), alpha)
 
 # Implementations for when the base color type is not changing
-# These might strip/add transparency, however
+# These might trip/add transparency, however
 _convert(::Type{Cout}, ::Type{Ccmp}, ::Type{Ccmp}, c) where {Cout<:Color3,Ccmp<:Color3} = Cout(comp1(c), comp2(c), comp3(c))
 _convert(::Type{A}, ::Type{Ccmp}, ::Type{Ccmp}, c, alpha=alpha(c)) where {A<:Transparent3,Ccmp<:Color3} = A(comp1(c), comp2(c), comp3(c), alpha)
 
@@ -97,10 +98,10 @@ _convert(::Type{A}, ::Type{C1}, ::Type{C2}, c, alpha=alpha(c)) where {A<:Transpa
 _convert(::Type{Cout}, ::Type{C1}, ::Type{C2}, c) where {Cout<:AbstractRGB,C1<:AbstractRGB,C2<:AbstractGray} = (g = convert(eltype(Cout), gray(c)); Cout(g, g, g))
 _convert(::Type{A}, ::Type{C1}, ::Type{C2}, c, alpha=alpha(c)) where {A<:TransparentRGB,C1<:AbstractRGB,C2<:AbstractGray} = (g = convert(eltype(A), gray(c)); A(g, g, g, alpha))
 
-convert(::Type{C}, x::Real) where {C<:Union{ColorantN{1}, TransparentColorN{2}}} = C(x)
-convert(::Type{C}, x::Real) where {C<:Union{AbstractRGB, TransparentRGB}} = C(x)
+convert(::Type{C}, x::Real) where {C<:ColorantN{1}} = C(x)
+convert(::Type{C}, x::Real) where {C<:AbstractRGB} = C(x, x, x)
 convert(::Type{C}, x::Real, alpha) where {C<:TransparentColorN{2}} = C(x, alpha)
-convert(::Type{C}, x::Real, alpha) where {C<:TransparentRGB} = C(x, alpha)
+convert(::Type{C}, x::Real, alpha) where {C<:TransparentRGB} = C(x, x, x, alpha)
 
 convert(::Type{T}, x::ColorantN{1}) where {T<:Real} = convert(T, comp1(x))
 

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -98,12 +98,19 @@ _convert(::Type{A}, ::Type{C1}, ::Type{C2}, c, alpha=alpha(c)) where {A<:Transpa
 _convert(::Type{Cout}, ::Type{C1}, ::Type{C2}, c) where {Cout<:AbstractRGB,C1<:AbstractRGB,C2<:AbstractGray} = (g = convert(eltype(Cout), gray(c)); Cout(g, g, g))
 _convert(::Type{A}, ::Type{C1}, ::Type{C2}, c, alpha=alpha(c)) where {A<:TransparentRGB,C1<:AbstractRGB,C2<:AbstractGray} = (g = convert(eltype(A), gray(c)); A(g, g, g, alpha))
 
-convert(::Type{C}, x::Real) where {C<:ColorantN{1}} = C(x)
-convert(::Type{C}, x::Real) where {C<:AbstractRGB} = C(x, x, x)
-convert(::Type{C}, x::Real, alpha) where {C<:TransparentColorN{2}} = C(x, alpha)
-convert(::Type{C}, x::Real, alpha) where {C<:TransparentRGB} = C(x, x, x, alpha)
+convert(::Type{RGB24},   x::Real) = RGB24(x, x, x)
+convert(::Type{ARGB32},  x::Real) = ARGB32(x, x, x)
+convert(::Type{ARGB32},  x::Real, alpha) = ARGB32(x, x, x, alpha)
+convert(::Type{Gray24},  x::Real) = Gray24(x)
+convert(::Type{AGray32}, x::Real) = AGray32(x)
+convert(::Type{AGray32}, x::Real, alpha) = AGray32(x, alpha)
 
-convert(::Type{T}, x::ColorantN{1}) where {T<:Real} = convert(T, comp1(x))
+convert(::Type{Gray{T}},  x::Real) where {T} = Gray{T}(x)
+convert(::Type{AGray{T}}, x::Real) where {T} = AGray{T}(x)
+convert(::Type{GrayA{T}}, x::Real) where {T} = GrayA{T}(x)
+
+convert(::Type{T}, x::Gray  ) where {T<:Real} = convert(T, x.val)
+convert(::Type{T}, x::Gray24) where {T<:Real} = convert(T, gray(x))
 
 (::Type{T})(x::ColorantN{1})  where {T<:Real} = T(comp1(x))
 

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -46,6 +46,7 @@ function _promote_rule(::Type{C1}, ::Type{C2}) where {C1<:Colorant, C2<:Colorant
     et, alpha = _promote_et(C1, C2), _promote_alpha(C1, C2)
     Cp1, Cp2 = parametric_colorant(C1), parametric_colorant(C2)
     color = _promote_color(base_color_type(Cp1), base_color_type(Cp2))
+
     _with_et(C::UnionAll, et) = isconcretetype(et) ? C{et} : C
     if !isabstracttype(color)
         alpha <: Color && return _with_et(color, et)
@@ -111,11 +112,10 @@ convert(::Type{GrayA{T}}, x::Real) where {T} = GrayA{T}(x)
 
 convert(::Type{T}, x::Gray  ) where {T<:Real} = convert(T, x.val)
 convert(::Type{T}, x::Gray24) where {T<:Real} = convert(T, gray(x))
+(::Type{T})(x::AbstractGray)  where {T<:Real} = T(gray(x))
 
-(::Type{T})(x::ColorantN{1})  where {T<:Real} = T(comp1(x))
-
-real(x::ColorantN{1}) = comp1(x)
-real(x::Type{<:ColorantN{1}}) = real(eltype(x))
+real(x::AbstractGray) = gray(x)
+real(::Type{C}) where {C<:AbstractGray} = real(eltype(C))
 
 # Define some constructors that just call convert since the fallback constructor in Base
 # is removed in Julia 0.7

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -126,6 +126,3 @@ coloralpha(c::C) where {C<:Color} = coloralpha(C)(c)
 coloralpha(c::C,a) where {C<:Color} = coloralpha(C)(c,a)
 coloralpha(c::C) where {C<:TransparentColor} = coloralpha(base_color_type(C))(color(c), alpha(c))
 coloralpha(c::C,a) where {C<:TransparentColor} = coloralpha(base_color_type(C))(color(c), a)
-
-# Tuple
-Tuple(c::Colorant{T, N}) where {T, N} = (comps(c)...,)::NTuple{N, T}

--- a/src/error_hints.jl
+++ b/src/error_hints.jl
@@ -2,15 +2,22 @@ MathTypes{T,C} = Union{AbstractRGB{T},TransparentRGB{C,T},AbstractGray{T},Transp
 
 # provided by https://github.com/JuliaLang/julia/pull/35094
 function register_hints()
-    isdefined(Base, :Experimental) && isdefined(Base.Experimental, :register_error_hint) || return
-    Base.Experimental.register_error_hint(MethodError) do io, exc, argtypes, kwargs
-        # In theory we could list every function supported by ColorVectorSpace.
-        # This list of functions is far from comprehensive but may be enough to catch many users.
-        if exc.f in (+, -, *, /) && any(T->T<:MathTypes || T<:Type{<:MathTypes}, argtypes)
-            print(io, "\nMath on colors is deliberately undefined in ColorTypes, but see the ColorVectorSpace package.")
-        end
-        if (exc.f === *) && all(T->T<:MathTypes || T<:Type{<:MathTypes}, argtypes)
-            print(io, "\nYou may also need `⋅`, `⊙`, or `⊗`.")
+    if isdefined(Base, :Experimental) && isdefined(Base.Experimental, :register_error_hint)
+        Base.Experimental.register_error_hint(MethodError) do io, exc, argtypes, kwargs
+            if exc.f in (one,) && argtypes[1] <: Union{Type{<:AbstractRGB}, AbstractRGB}
+                print(io, "\nYou may need to `using ColorVectorSpace`.")
+            end
+            if exc.f in (ones,) && argtypes[1] <: Type{<:AbstractRGB}
+                print(io, "\nYou may need to `using ColorVectorSpace`.")
+            end
+            # In theory we could list every function supported by ColorVectorSpace.
+            # This list of functions is far from comprehensive but may be enough to catch many users.
+            if exc.f in (+, -, *, /) && any(T->T<:MathTypes || T<:Type{<:MathTypes}, argtypes)
+                print(io, "\nMath on colors is deliberately undefined in ColorTypes, but see the ColorVectorSpace package.")
+            end
+            if (exc.f === *) && all(T->T<:MathTypes || T<:Type{<:MathTypes}, argtypes)
+                print(io, "\nYou may also need `⋅`, `⊙`, or `⊗`.")
+            end
         end
     end
 end

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -1,43 +1,5 @@
-# iterator
-struct ComponentIterator{C<:Colorant}
-    c::C
-end
-
-eltype(::Type{ComponentIterator{C}}) where {T, C <: Colorant{T}} = T
-length(::ComponentIterator{C}) where {N, C <: ColorantN{N}} = N
-
-function Base.iterate(itr::ComponentIterator{C}, state::Int=0) where {N, C <: ColorantN{N}}
-    state < 0 && return nothing
-    state >= N && return nothing
-    state += 1
-    return (itr[state], state)
-end
-
-@inline function Base.getindex(itr::ComponentIterator{C}, i::Integer) where {N, C <: ColorantN{N}}
-    N > 0 && i == 1 && return comp1(itr.c)
-    N > 1 && i == 2 && return comp2(itr.c)
-    N > 2 && i == 3 && return comp3(itr.c)
-    N > 3 && i == 4 && return comp4(itr.c)
-    N > 4 && i == 5 && return comp5(itr.c)
-    throw(BoundsError(itr, i))
-end
-Base.getindex(itr::ComponentIterator, r::AbstractRange) = Tuple(itr[i] for i in r)
-Base.getindex(itr::ComponentIterator, ::Colon) = itr
-
-Base.firstindex(::ComponentIterator) = 1
-Base.lastindex(itr::ComponentIterator) = length(itr)
-
-function Base.BroadcastStyle(::Type{<:ComponentIterator{C}}) where {T, N, C <: Colorant{T, N}}
-    Base.BroadcastStyle(NTuple{N, T})
-end
-Base.axes(::ComponentIterator{C}) where {N, C <: ColorantN{N}} = (Base.OneTo(N),)
-Base.ndims(::Type{ComponentIterator{C}}) where {C} = 1
-function Base.broadcastable(itr::ComponentIterator{C}) where {T, N, C <: Colorant{T, N}}
-    (itr...,)::NTuple{N, T}
-end
-
-comps(c::Colorant) = ComponentIterator(c) # TODO: design public APIs
-
+struct BoolTuple end
+@inline BoolTuple(args::Bool...) = args
 
 # comparison
 _is_same_colorspace(a, b) = base_colorant_type(a) === base_colorant_type(b)
@@ -49,7 +11,7 @@ _is_same_colorspace(a::TransparentRGB, b::TransparentRGB) = true
 
 function ==(a::ColorantN{N}, b::ColorantN{N}) where {N}
     _is_same_colorspace(a, b) || return false
-    all(comps(a) .== comps(b))
+    all(_mapc(BoolTuple, ==, a, b))
 end
 ==(x::Number, y::AbstractGray) = x == gray(y)
 ==(x::AbstractGray, y::Number) = ==(y, x)
@@ -58,7 +20,7 @@ end
 function isapprox(a::ColorantN{N}, b::ColorantN{N}; kwargs...) where {N}
     _is_same_colorspace(a, b) || return false
     componentapprox(x, y) = isapprox(x, y; kwargs...)
-    all(componentapprox.(comps(a), comps(b)))
+    all(_mapc(BoolTuple, componentapprox, a, b))
 end
 isapprox(a::Colorant, b::Colorant; kwargs...) = false
 isapprox(a::Number, b::AbstractGray; kwargs...) = isapprox(a, gray(b); kwargs...)
@@ -230,10 +192,30 @@ color(s), returning an output color in the same colorspace.
     julia> mapc(+, RGB(0.1,0.8,0.3), RGB(0.5,0.5,0.5))
     RGB{Float64}(0.6,1.3,0.8)
 """
-@inline mapc(f, c::C) where {C<:Colorant} = base_colorant_type(C)(f.(comps(c))...)
+@inline mapc(f, c::C) where {C<:ColorantN{1}} =
+    base_colorant_type(C)(f(comp1(c)))
+@inline mapc(f, c::C) where {C<:ColorantN{2}} =
+    base_colorant_type(C)(f(comp1(c)), f(comp2(c)))
+@inline mapc(f, c::C) where {C<:ColorantN{3}} =
+    base_colorant_type(C)(f(comp1(c)), f(comp2(c)), f(comp3(c)))
+@inline mapc(f, c::C) where {C<:ColorantN{4}} =
+    base_colorant_type(C)(f(comp1(c)), f(comp2(c)), f(comp3(c)), f(comp4(c)))
+@inline mapc(f, c::C) where {C<:ColorantN{5}} =
+    base_colorant_type(C)(f(comp1(c)), f(comp2(c)), f(comp3(c)), f(comp4(c)), f(comp5(c)))
+
 @inline mapc(f, x::Number) = f(x)
 
-@inline mapc(f::F, x, y) where {F} = _same_colorspace(x, y)(f.(comps(x), comps(y))...)
+mapc(f::F, x, y) where F = _mapc(_same_colorspace(x,y), f, x, y)
+_mapc(::Type{C}, f, x::ColorantN{1}, y::ColorantN{1}) where C =
+    C(f(comp1(x), comp1(y)))
+_mapc(::Type{C}, f, x::ColorantN{2}, y::ColorantN{2}) where C =
+    C(f(comp1(x), comp1(y)), f(comp2(x), comp2(y)))
+_mapc(::Type{C}, f, x::ColorantN{3}, y::ColorantN{3}) where C =
+    C(f(comp1(x), comp1(y)), f(comp2(x), comp2(y)), f(comp3(x), comp3(y)))
+_mapc(::Type{C}, f, x::ColorantN{4}, y::ColorantN{4}) where C =
+    C(f(comp1(x), comp1(y)), f(comp2(x), comp2(y)), f(comp3(x), comp3(y)), f(comp4(x), comp4(y)))
+_mapc(::Type{C}, f, x::ColorantN{5}, y::ColorantN{5}) where C =
+    C(f(comp1(x), comp1(y)), f(comp2(x), comp2(y)), f(comp3(x), comp3(y)), f(comp4(x), comp4(y)), f(comp5(x), comp5(y)))
 
 _same_colorspace(x::Colorant, y::Colorant) = _same_colorspace(base_colorant_type(x),
                                                               base_colorant_type(y))
@@ -256,7 +238,12 @@ whereas for RGB
 
 If `c` has an alpha channel, it is always the last one to be folded into the reduction.
 """
-@inline reducec(op, v0, c::C) where {C <: Colorant} = reduce(op, Tuple(c); init=v0)
+@inline reducec(op, v0, c::ColorantN{1}) = op(v0, comp1(c))
+@inline reducec(op, v0, c::ColorantN{2}) = op(comp2(c), op(v0, comp1(c)))
+@inline reducec(op, v0, c::ColorantN{3}) = op(comp3(c), op(comp2(c), op(v0, comp1(c))))
+@inline reducec(op, v0, c::ColorantN{4}) = op(comp4(c), op(comp3(c), op(comp2(c), op(v0, comp1(c)))))
+@inline reducec(op, v0, c::ColorantN{5}) = op(comp5(c), op(comp4(c), op(comp3(c), op(comp2(c), op(v0, comp1(c))))))
+
 @inline reducec(op, v0, x::Number) = op(v0, x)
 
 """
@@ -274,5 +261,13 @@ whereas for RGB
 
 If `c` has an alpha channel, it is always the last one to be folded into the reduction.
 """
-@inline mapreducec(f, op, v0, c::C) where {C <: Colorant} = reduce(op, f.(comps(c)); init=v0)
+@inline mapreducec(f, op, v0, c::ColorantN{1}) = op(v0, f(comp1(c)))
+@inline mapreducec(f, op, v0, c::ColorantN{2}) = op(f(comp2(c)), op(v0, f(comp1(c))))
+@inline mapreducec(f, op, v0, c::ColorantN{3}) =
+    op(f(comp3(c)), op(f(comp2(c)), op(v0, f(comp1(c)))))
+@inline mapreducec(f, op, v0, c::ColorantN{4}) =
+    op(f(comp4(c)), op(f(comp3(c)), op(f(comp2(c)), op(v0, f(comp1(c))))))
+@inline mapreducec(f, op, v0, c::ColorantN{5}) =
+    op(f(comp5(c)), op(f(comp4(c)), op(f(comp3(c)), op(f(comp2(c)), op(v0, f(comp1(c)))))))
+
 @inline mapreducec(f, op, v0, x::Number) = op(v0, f(x))

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -145,11 +145,11 @@ function rand(r::AbstractRNG, ::SamplerType{C}) where {T, C<:Colorant{T}}
 end
 function rand(r::AbstractRNG, ::SamplerType{C}) where {T<:Rand01Type, C0<:AbstractGray{T},
                                                        C<:Union{C0, TransparentGray{C0, T}}}
-    mapc(_ -> rand(r, T), C())
+    mapc(_ -> rand(r, T), base_colorant_type(C)())
 end
 function rand(r::AbstractRNG, ::SamplerType{C}) where {T<:Rand01Type, C0<:AbstractRGB{T},
                                                        C<:Union{C0, TransparentRGB{C0, T}}}
-    mapc(_ -> rand(r, T), C())
+    mapc(_ -> rand(r, T), base_colorant_type(C)())
 end
 function rand(r::AbstractRNG, ::SamplerType{AGray32}) # Gray24 has little benefit of specialization.
     reinterpret(AGray32, (rand(r, UInt32) & 0xff0000ff) * 0x010101)

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -243,11 +243,10 @@ _same_colorspace(::Type{C}, ::Type{C}) where {C<:Colorant} = C
 
 """
     reducec(op, v0, c)
-    reducec(op, c; [init])
 
-Reduce across color channels of `c` with the binary operator `op`.
-`v0` or `init` is the neutral element used to initiate the reduction.
-For grayscale,
+Reduce across color channels of `c` with the binary operator
+`op`. `v0` is the neutral element used to initiate the reduction. For
+grayscale,
 
     reducec(op, v0, c::Gray) = op(v0, comp1(c))
 
@@ -256,24 +255,16 @@ whereas for RGB
     reducec(op, v0, c::RGB) = op(comp3(c), op(comp2(c), op(v0, comp1(c))))
 
 If `c` has an alpha channel, it is always the last one to be folded into the reduction.
-
-!!! compat "ColorTypes 0.12"
-    The keyword argument `init` and its omission using the default value require
-    ColorTypes v0.12 or later.
 """
 @inline reducec(op, v0, c::C) where {C <: Colorant} = reduce(op, Tuple(c); init=v0)
 @inline reducec(op, v0, x::Number) = op(v0, x)
-@inline reducec(op, c::C; kw...) where {C <: Colorant} = reduce(op, Tuple(c); kw...)
-@inline reducec(op, x::Number; kw...) = reduce(op, x; kw...)
 
 """
     mapreducec(f, op, v0, c)
-    mapreducec(f, op, c; [init])
 
 Reduce across color channels of `c` with the binary operator `op`,
-first applying `f` to each channel.
-`v0` or `init` is the neutral element used to initiate the reduction.
-For grayscale,
+first applying `f` to each channel. `v0` is the neutral element used
+to initiate the reduction. For grayscale,
 
     mapreducec(f, op, v0, c::Gray) = op(v0, f(comp1(c)))
 
@@ -282,12 +273,6 @@ whereas for RGB
     mapreducec(f, op, v0, c::RGB) = op(f(comp3(c)), op(f(comp2(c)), op(v0, f(comp1(c)))))
 
 If `c` has an alpha channel, it is always the last one to be folded into the reduction.
-
-!!! compat "ColorTypes 0.12"
-    The keyword argument `init` and its omission using the default value require
-    ColorTypes v0.12 or later.
 """
 @inline mapreducec(f, op, v0, c::C) where {C <: Colorant} = reduce(op, f.(comps(c)); init=v0)
 @inline mapreducec(f, op, v0, x::Number) = op(v0, f(x))
-@inline mapreducec(f, op, c::C; kw...) where {C <: Colorant} = reduce(op, f.(comps(c)); kw...)
-@inline mapreducec(f, op, x::Number; kw...) = reduce(op, f(x); kw...)

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -44,44 +44,21 @@ hash(c::TransparentRGB, hx::UInt) = hash(alpha(c), hash(blue(c), hash(green(c), 
 Base.adjoint(c::Colorant) = c
 
 # gamut{min,max}
-# the following values are based on the bounding boxes of sRGB gamut (D65).
-gamutmin(::Type{<:ColorantN{N}}) where {N} = ntuple(_ -> 0, N) # fallback
+gamutmax(::Type{T}) where {T<:HSV} = (360,1,1)
+gamutmin(::Type{T}) where {T<:HSV} = (0,0,0)
+gamutmax(::Type{T}) where {T<:HSL} = (360,1,1)
+gamutmin(::Type{T}) where {T<:HSL} = (0,0,0)
+gamutmax(::Type{T}) where {T<:Lab} = (100,128,128)
+gamutmin(::Type{T}) where {T<:Lab} = (0,-127,-127)
+gamutmax(::Type{T}) where {T<:LCHab} = (100,1,360) # FIXME
+gamutmin(::Type{T}) where {T<:LCHab} = (0,0,0)
+gamutmax(::Type{T}) where {T<:YIQ} = (1,0.5226,0.5226) # FIXME
+gamutmin(::Type{T}) where {T<:YIQ} = (0,-0.5957,-0.5957) # FIXME
 
-gamutmax(::Type{<:AbstractGray}) = (1,)
-gamutmax(::Type{<:AbstractRGB}) = (1, 1, 1)
-
-gamutmax(::Type{<:Union{HSV, HSL, HSI}}) = (360, 1, 1)
-
-gamutmax(::Type{<:XYZ}) = (0.9505, 1, 1.089)
-
-gamutmax(::Type{<:xyY}) = (0.3127, 0.3290, 1)
-
-gamutmax(::Type{<:Lab}) = (100, 98.2343, 94.4779)
-gamutmin(::Type{<:Lab}) = (0, -86.1827, -107.8602)
-
-gamutmax(::Type{<:Luv}) = (100, 175.0150, 107.3985)
-gamutmin(::Type{<:Luv}) = (0, -83.077, -134.1030)
-
-gamutmax(::Type{<:LCHab}) = (100, 133.8076, 360)
-
-gamutmax(::Type{<:LCHuv}) = (100, 179.0414, 360)
-
-gamutmax(::Type{<:DIN99}) = (100.0013, 36.1753, 31.1551)
-gamutmin(::Type{<:DIN99}) = (0, -27.4504, -33.3955)
-
-gamutmax(::Type{<:DIN99d}) = (100.0002, 43.6867, 43.6318)
-gamutmin(::Type{<:DIN99d}) = (0, -38.1436, -45.8498)
-
-gamutmax(::Type{<:DIN99o}) = (99.9997, 45.5242, 44.3662)
-gamutmin(::Type{<:DIN99o}) = (0, -40.1101, -40.4900)
-
-gamutmax(::Type{<:LMS}) = (0.9493, 1.0354, 1.0872)
-
-gamutmax(::Type{<:YIQ}) = (1, 0.5957, 0.5226)
-gamutmin(::Type{<:YIQ}) = (0, -0.5957, -0.5226)
-
-gamutmax(::Type{<:YCbCr}) = (235, 240, 240)
-gamutmin(::Type{<:YCbCr}) = (16, 16, 16)
+gamutmax(::Type{T}) where {T<:AbstractGray} = (1,)
+gamutmin(::Type{T}) where {T<:AbstractGray} = (0,)
+gamutmax(::Type{T}) where {T<:AbstractRGB} = (1,1,1)
+gamutmin(::Type{T}) where {T<:AbstractRGB} = (0,0,0)
 
 gamutmax(::Type{C}) where {C<:TransparentColor} = (gamutmax(color_type(C))..., 1)
 gamutmin(::Type{C}) where {C<:TransparentColor} = (gamutmin(color_type(C))..., 0)

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -54,13 +54,6 @@ end
 ==(x::Number, y::AbstractGray) = x == gray(y)
 ==(x::AbstractGray, y::Number) = ==(y, x)
 
-function Base.isequal(a::ColorantN{N}, b::ColorantN{N}) where {N}
-    _is_same_colorspace(a, b) || return false
-    all(isequal.(comps(a), comps(b)))
-end
-Base.isequal(x::Number, y::AbstractGray) = isequal(x, gray(y))
-Base.isequal(x::AbstractGray, y::Number) = isequal(y, x)
-
 
 function isapprox(a::ColorantN{N}, b::ColorantN{N}; kwargs...) where {N}
     _is_same_colorspace(a, b) || return false

--- a/src/show.jl
+++ b/src/show.jl
@@ -1,49 +1,20 @@
 
 function show(io::IO, c::Colorant)
-    if get(io, :typeinfo, Any) === typeof(c)
-        print(io, colorant_string(typeof(c)))
-    else
-        show_colorant_string_with_eltype(io, typeof(c))
-    end
+    show_colorant_string_with_eltype(io, typeof(c))
     _show_components(io, c)
 end
 
-function show(io::IO, c::AbstractGray)
-    if get(io, :typeinfo, Any) === typeof(c)
-        show(_components_iocontext(io, c), comp1(c))
+# Special handling for Normed types: don't print the giant type name
+function show(io::IO, c::ColorantNormed)
+    show_colorant_string_with_eltype(io, typeof(c))
+    if typeof(c) === base_colorant_type(typeof(c)) # non-parametric
+        _show_components(io, c) # with trailing "N0f8" unless :compat=>true
     else
-        show_colorant_string_with_eltype(io, typeof(c))
-        _show_components(io, c)
+        _show_components(IOContext(io, :compact=>true), c)
     end
 end
 
-function show(io::IO, c::AbstractGray{Bool})
-    if get(io, :typeinfo, Any) === typeof(c)
-        print(io, gray(c) ? '1' : '0')
-    else
-        show_colorant_string_with_eltype(io, typeof(c))
-        print(io, gray(c) ? "(1)" : "(0)")
-    end
-end
-
-
-@inline function _components_iocontext(io::IO, c::Colorant{T}) where T
-    if typeof(c) === base_colorant_type(c)
-        # For non-parametric colors, we do not set :typeinfo since they do not
-        # explicitly show their element type. Therefore, the suffix "N0f8" is
-        # displayed in RGB24 etc. unless :compact=>true.
-        return io
-    elseif T === Float64
-        return io
-    elseif T <: FixedPoint # workaround for FPN v0.8 or earlier
-        return IOContext(io, :typeinfo => T, :compact => true)
-    else
-        return IOContext(io, :typeinfo => T)
-    end
-end
-
-function _show_components(io::IO, c::Colorant{T, N}) where {T, N}
-    io = _components_iocontext(io, c)
+function _show_components(io::IO, c::Colorant{T,N}) where {T, N}
     print(io, '(')
     for i = 1:N
         i == 1 && show(io, comp1(c))
@@ -51,19 +22,16 @@ function _show_components(io::IO, c::Colorant{T, N}) where {T, N}
         i == 3 && show(io, comp3(c))
         i == 4 && show(io, comp4(c))
         i == 5 && show(io, comp5(c))
-        print(io, i < N ? ", " : ")")
+        print(io, i < N ? ',' : ')') # without spaces
     end
 end
 
-if VERSION < v"1.6.0-DEV.356" # JuliaLang/julia#36107
-    function Base.showarg(io::IO, a::Array{C}, toplevel) where C<:Colorant
-        toplevel || print(io, "::")
-        print(io, "Array{")
-        show_colorant_string_with_eltype(io, C)
-        print(io, ',', ndims(a), '}')
-        is_parametric_fixed = C <: Colorant{<:FixedPoint} && !isempty(C.parameters)
-        toplevel && is_parametric_fixed && print(io, " with eltype ", C)
-    end
+function Base.showarg(io::IO, a::Array{C}, toplevel) where C<:Colorant
+    toplevel || print(io, "::")
+    print(io, "Array{")
+    show_colorant_string_with_eltype(io, C)
+    print(io, ",$(ndims(a))}")
+    toplevel && print(io, " with eltype ", C)
 end
 
 

--- a/src/show.jl
+++ b/src/show.jl
@@ -46,7 +46,11 @@ function _show_components(io::IO, c::Colorant{T, N}) where {T, N}
     io = _components_iocontext(io, c)
     print(io, '(')
     for i = 1:N
-        show(io, comps(c)[i])
+        i == 1 && show(io, comp1(c))
+        i == 2 && show(io, comp2(c))
+        i == 3 && show(io, comp3(c))
+        i == 4 && show(io, comp4(c))
+        i == 5 && show(io, comp5(c))
         print(io, i < N ? ", " : ")")
     end
 end

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -226,7 +226,6 @@ base_colorant_type(::Type{<:Number}) = Gray
 @pure basetype(@nospecialize(C)) = Base.typename(C).wrapper
 
 abstract_basetype(::Type{<:AbstractRGB}) = AbstractRGB
-abstract_basetype(::Type{<:AbstractGray}) = AbstractGray
 abstract_basetype(::Type{<:ColorN{N}}) where N = ColorN{N}
 abstract_basetype(::Type{<:Color}) = Color
 function abstract_basetype(::Type{TC}) where {TC<:TransparentColor}

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -478,9 +478,13 @@ AHSV{Float64}(NaN, NaN, NaN, NaN)
 ```
 """
 nan(::Type{T}) where {T<:AbstractFloat} = convert(T, NaN)
-nan(::Type{C}) where {T<:AbstractFloat, N, C<:Colorant{T, N}} = C(ntuple(_ -> nan(T), Val(N))...)
+nan(::Type{C}) where {T<:AbstractFloat, C<:Colorant{T}} = mapc(_ -> nan(T), zero(C))
 
-zero(::Type{C}) where {N, C<:ColorantN{N}} = C(ntuple(_ -> 0, Val(N))...)
+zero(::Type{C}) where {C<:ColorantN{1}} = C(0)
+zero(::Type{C}) where {C<:ColorantN{2}} = C(0, 0)
+zero(::Type{C}) where {C<:ColorantN{3}} = C(0, 0, 0)
+zero(::Type{C}) where {C<:ColorantN{4}} = C(0, 0, 0, 0)
+zero(::Type{C}) where {C<:ColorantN{5}} = C(0, 0, 0, 0, 0)
 zero(c::Colorant) = zero(typeof(c))
 
 oneunit(::Type{C}) where {C<:Colorant} = throw_oneunit_error(C)

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -461,10 +461,10 @@ Return a color instance of the specified type in which all components are NaN.
 # Examples
 ```jldoctest; setup = :(using ColorTypes)
 julia> ColorTypes.nan(RGB{Float32})
-RGB{Float32}(NaN, NaN, NaN)
+RGB{Float32}(NaN32,NaN32,NaN32)
 
 julia> ColorTypes.nan(AHSV{Float64})
-AHSV{Float64}(NaN, NaN, NaN, NaN)
+AHSV{Float64}(NaN,NaN,NaN,NaN)
 ```
 """
 nan(::Type{T}) where {T<:AbstractFloat} = convert(T, NaN)

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -60,7 +60,6 @@ hue(c::Union{C,AlphaColor{C},ColorAlpha{C}}) where {C<:Luv} =
 _comp(::Val{N}, c::Colorant) where N = getfield(c, N)
 _comp(::Val{N}, c::AlphaColor) where N = getfield(c, N + 1)
 _comp(::Val{N}, c::AlphaColorN{N}) where N = alpha(c)
-_comp(::Val{N}, c::ColorAlphaN{N}) where N = alpha(c)
 
 @noinline function _comp_error(c::ColorantN{N}, n::Int) where N
     io = IOBuffer()

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -7,34 +7,33 @@ without an alpha channel, it will always return 1.
 alpha(c::TransparentColor) = c.alpha
 alpha(c::Color)   = oneunit(eltype(c))
 alpha(c::RGB24)   = N0f8(1)
-alpha(c::ARGB32)  = reinterpret(N0f8, (c.color >> 0x18) % UInt8)
-alpha(c::AGray32) = reinterpret(N0f8, (c.color >> 0x18) % UInt8)
-alpha(x::Number)  = convert(eltype(ccolor(Gray, typeof(x))), oneunit(x))  # ensures it's a type supported by Gray (which has widest eltype support)
+alpha(c::ARGB32)  = N0f8((c.color & 0xff000000)>>24, 0)
+alpha(c::AGray32) = N0f8((c.color & 0xff000000)>>24, 0)
 
 "`red(c)` returns the red component of an `AbstractRGB` opaque or transparent color."
 red(c::AbstractRGB   ) = c.r
 red(c::TransparentRGB) = c.r
-red(c::RGB24)  = reinterpret(N0f8, (c.color >> 0x10) % UInt8)
-red(c::ARGB32) = reinterpret(N0f8, (c.color >> 0x10) % UInt8)
+red(c::RGB24)  = N0f8((c.color & 0x00ff0000)>>16, 0)
+red(c::ARGB32) = N0f8((c.color & 0x00ff0000)>>16, 0)
 
 "`green(c)` returns the green component of an `AbstractRGB` opaque or transparent color."
 green(c::AbstractRGB   ) = c.g
 green(c::TransparentRGB) = c.g
-green(c::RGB24)  = reinterpret(N0f8, (c.color >> 0x08) % UInt8)
-green(c::ARGB32) = reinterpret(N0f8, (c.color >> 0x08) % UInt8)
+green(c::RGB24)  = N0f8((c.color & 0x0000ff00)>>8, 0)
+green(c::ARGB32) = N0f8((c.color & 0x0000ff00)>>8, 0)
 
 "`blue(c)` returns the blue component of an `AbstractRGB` opaque or transparent color."
 blue(c::AbstractRGB   ) = c.b
 blue(c::TransparentRGB) = c.b
-blue(c::RGB24)  = reinterpret(N0f8, c.color % UInt8)
-blue(c::ARGB32) = reinterpret(N0f8, c.color % UInt8)
+blue(c::RGB24)  = N0f8(c.color & 0x000000ff, 0)
+blue(c::ARGB32) = N0f8(c.color & 0x000000ff, 0)
 
 "`gray(c)` returns the gray component of a grayscale opaque or transparent color."
 gray(c::Gray)    = c.val
 gray(c::TransparentGray) = c.val
-gray(c::Gray24)  = reinterpret(N0f8, c.color % UInt8)
-gray(c::AGray32) = reinterpret(N0f8, c.color % UInt8)
-gray(x::Number)  = convert(eltype(ccolor(Gray, typeof(x))), x)   # ensures it's a type supported by Gray
+gray(c::Gray24)  = N0f8(c.color & 0x000000ff, 0)
+gray(c::AGray32) = N0f8(c.color & 0x000000ff, 0)
+gray(x::Number)  = x
 
 """
 `chroma(c)` returns the chroma of a `Lab`, `Luv` or their variants color.

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -124,14 +124,6 @@ to_top(::Type{Colorant{T,N}}) where {T,N} = Colorant{T,N}
 
 to_top(c::Colorant) = to_top(typeof(c))
 
-
-# Return the number of components in the color
-# Note this is different from div(sizeof(c), sizeof(eltype(c))) (e.g., XRGB)
-length(::Type{<:ColorantN{N}}) where N = N
-
-length(c::Colorant) = length(typeof(c))
-
-
 # eltype(RGB{Float32}) -> Float32
 eltype(::Type{C}) where {C<:Colorant{T}} where {T} = T
 

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -477,10 +477,6 @@ zero(::Type{C}) where {C<:ColorantN{4}} = C(0, 0, 0, 0)
 zero(::Type{C}) where {C<:ColorantN{5}} = C(0, 0, 0, 0, 0)
 zero(c::Colorant) = zero(typeof(c))
 
-oneunit(::Type{C}) where {C<:Colorant} = throw_oneunit_error(C)
-@noinline function throw_oneunit_error(@nospecialize(C))
-    throw(ArgumentError("`oneunit` for $C is not defined. Perhaps the meaning is not clear."))
-end
 oneunit(::Type{C}) where {C<:AbstractGray} = C(1)
 # It's not clear what `oneunit` means for most Color3s,
 # but for AbstractRGB, XYZ, and LMS, it's OK
@@ -490,8 +486,9 @@ oneunit(::Type{C}) where {C<:TransparentColor} = C(oneunit(color_type(C)))
 oneunit(::Type{C}) where {C<:Union{AGray, GrayA}} = C(1, 1) # workaround for inconsistent `color_type`
 oneunit(c::Colorant) = oneunit(typeof(c))
 
-one(::Type{C}) where {C<:Colorant} = one(eltype_default(C))
-one(::Type{C}) where {T, C<:Colorant{T}} = one(T)
-one(c::Colorant) = one(typeof(c))
+function Base.one(::Type{C}) where {C<:Gray}
+    Base.depwarn("one($C) will soon switch to returning 1; you might need to switch to `oneunit`", :one)
+    C(1)
+end
 
 Base.broadcastable(x::Colorant) = Ref(x)

--- a/src/types.jl
+++ b/src/types.jl
@@ -512,7 +512,12 @@ _real(x::AbstractGray) = real(x)
 function (::Type{C})() where {N, C <: ColorantN{N}}
     d0 = zero(eltype_default(C))
     dx = C <: TransparentColor ? oneunit(eltype_default(C)) : d0
-    C(ntuple(_ -> d0, Val(N - 1))..., dx)
+    N == 1 && return _new_colorant(C, dx)
+    N == 2 && return _new_colorant(C, d0, dx)
+    N == 3 && return _new_colorant(C, d0, d0, dx)
+    N == 4 && return _new_colorant(C, d0, d0, d0, dx)
+    N == 5 && return _new_colorant(C, d0, d0, d0, d0, dx)
+    throw(MethodError(C, ()))
 end
 
 (::Type{C})(x         ) where {C <: Color    } = _new_colorant(C, x)

--- a/src/types.jl
+++ b/src/types.jl
@@ -390,6 +390,10 @@ end
 Gray24() = reinterpret(Gray24, UInt32(0))
 _Gray24(val::UInt8) = (g = UInt32(val); reinterpret(Gray24, g<<16 | g<<8 | g))
 Gray24(val::N0f8) = _Gray24(reinterpret(val))
+function Gray24(val::Real)
+    checkval(Gray24, val)
+    Gray24(val%N0f8)
+end
 
 """
 `AGray32` uses a `UInt32` representation of color, 0xAAIIIIII, where
@@ -410,7 +414,7 @@ end
 AGray32() = reinterpret(AGray32, 0xff000000)
 _AGray32(val::UInt8, alpha::UInt8 = 0xff) = (g = UInt32(val); reinterpret(AGray32, UInt32(alpha)<<24 | g<<16 | g<<8 | g))
 AGray32(val::N0f8, alpha::N0f8 = N0f8(1)) = _AGray32(reinterpret(val), reinterpret(alpha))
-function AGray32(val::Real, alpha)
+function AGray32(val::Real, alpha = 1)
     checkval(AGray32, val, alpha)
     AGray32(val%N0f8, alpha%N0f8)
 end
@@ -611,18 +615,6 @@ end
 for C in (RGB, BGR, XRGB, RGBX)
     @eval (::Type{$C{T}})(r::GrayLike, g::GrayLike, b::GrayLike) where T = $C{T}(gray(r), gray(g), gray(b))
 end
-function (::Type{C})(x::UInt32) where C <: Union{RGB24, Gray24, ARGB32, AGray32}
-    x <= UInt32(1) || throw_bit_pattern_error(C, x)
-    reinterpret(C, C <: Color ? (-x) & 0xffffff : (-x) | 0xff000000)
-end
-function (::Type{C})(x::GrayLike) where C <: Union{RGB24, Gray24, ARGB32, AGray32}
-    checkval(C, real(x))
-    v = _rem(real(x), N0f8)
-    return C <: Union{RGB24, ARGB32} ? C(v, v, v) : C(v)
-end
-function (::Type{C})(x) where C <: Union{RGB24, Gray24, ARGB32, AGray32}
-    convert(C, x)
-end
 
 alphacolor(::Type{C}) where {C<:AlphaColor} = base_colorant_type(C)
 alphacolor(::Type{C}) where {C<:ColorAlpha} = alphacolor(base_color_type(C))
@@ -683,16 +675,26 @@ end
     isok(T, a, b) & isok(T, c, d) & isok(T, e) || throw_colorerror(C, (a, b, c, d, e))
 end
 
-checkval(::Type{C}, args::Vararg{T}) where {T<:Normed, C<:Colorant{T}} = nothing
-checkval(::Type{C}, args...) where {C<:Colorant} = nothing
+checkval(::Type{C}, a::T) where {T<:Normed, C<:Colorant{T}} = nothing
+checkval(::Type{C}, a::T, b::T) where {T<:Normed, C<:Colorant{T}} = nothing
+checkval(::Type{C}, a::T, b::T, c::T) where {T<:Normed, C<:Colorant{T}} = nothing
+checkval(::Type{C}, a::T, b::T, c::T, d::T) where {T<:Normed, C<:Colorant{T}} = nothing
+checkval(::Type{C}, a::T, b::T, c::T, d::T, e::T) where {T<:Normed, C<:Colorant{T}} = nothing
+
+checkval(::Type{C}, a) where {C<:Colorant} = nothing
+checkval(::Type{C}, a, b) where {C<:Colorant} = nothing
+checkval(::Type{C}, a, b, c) where {C<:Colorant} = nothing
+checkval(::Type{C}, a, b, c, d) where {C<:Colorant} = nothing
+checkval(::Type{C}, a, b, c, d, e) where {C<:Colorant} = nothing
 
 
 function throw_colorerror_(::Type{T}, values) where T<:Normed
-    Tmin = repr(typemin(T), context=:compact=>true)
-    Tmax = repr(typemax(T), context=:compact=>true)
+    io = IOBuffer()
+    show(IOContext(io, :compact=>true), typemin(T)); Tmin = String(take!(io))
+    show(IOContext(io, :compact=>true), typemax(T)); Tmax = String(take!(io))
     bitstring = sizeof(T) == 1 ? "an 8-bit" : "a $(8*sizeof(T))-bit"
     throw(ArgumentError("""
-component type $T is $bitstring type representing $(2^(8*sizeof(T))) values from $Tmin to $Tmax,
+element type $T is $bitstring type representing $(2^(8*sizeof(T))) values from $Tmin to $Tmax,
   but the values $values do not lie within this range.
   See the READMEs for FixedPointNumbers and ColorTypes for more information."""))
 end
@@ -706,24 +708,42 @@ function throw_colorerror(::Type{C}, values::Tuple{Vararg{Integer}}) where C<:Co
         vstr = "$values are integers"
     end
     Cstr = colorant_string_with_eltype(C)
-    args = join(map(v -> "$v/255", values), ", ")
+    args = join(map(v->"$v/255", values), ',')
     throw(ArgumentError("""
-The components of $(nameof(C)) are normalized to the range 0-1,
-  but $vstr in the range 0-255.
+$vstr in the range 0-255, but integer inputs are encoded with the N0f8
+  type, an 8-bit type representing 256 discrete values between 0 and 1.
   Consider dividing your input values by 255, for example: $Cstr($args)
-  The component type N0f8 is an 8-bit type representing 256 values from 0 to 1.
-  You can also use `reinterpret(N0f8, x % UInt8)` to encode the input into N0f8.
+  Or use `reinterpret(N0f8, x)` if `x` is a `UInt8`.
   See the READMEs for FixedPointNumbers and ColorTypes for more information."""))
 end
-function throw_colorerror(::Type{C}, values::Tuple) where {T<:Normed, C<:Colorant{T}}
-    throw_colorerror_(T, values)
-end
+function throw_colorerror(::Type{C},
+                          values::Tuple{Vararg{Integer}}) where C<:Union{RGB24,ARGB32,Gray24,AGray32}
+    # For consistency, some sets of `UInt32` inputs are valid for the
+    # constructors of these non-parametric colors,
+    # e.g. `RGB24(UInt32(1), UInt32(0), UInt32(0))` is valid.
+    # Therefore, this error should be thrown after the range checking.
 
-function throw_bit_pattern_error(@nospecialize(C), value)
-    hex = string(value, base=16, pad=8)
+    # We want to suggest `reinterpret` only when users call the 1-arg version of
+    # constructors (e.g. `RGB24(0x123456)`) or try to convert a `UInt32` number.
+    # However, the current implementation cannot distinguish what the users
+    # actually called.
+    # So, we suggest using `reinterpret` when the input is opaque "gray".
+    tripled(t) = t[1] isa UInt32 && t[1] === t[2] && t[2] === t[3]
+    if C === RGB24 && length(values) == 3 && tripled(values)
+    elseif C === ARGB32 && length(values) == 4 && tripled(values) && values[4] == 1
+    elseif C === Gray24 && length(values) == 1 && values[1] isa UInt32
+    elseif C === AGray32 && length(values) == 2 && values[1] isa UInt32 && values[2] == 1
+    else
+        throw_colorerror_(N0f8, values)
+    end
+    hex = string(values[1], base=16, pad=8)
     throw(ArgumentError("""
 $C cannot be constructed or converted directly from a UInt32 input as a bit pattern.
   Use `reinterpret($C, 0x$hex)` instead."""))
+end
+
+function throw_colorerror(::Type{C}, values::Tuple) where {T<:Normed, C<:Colorant{T}}
+    throw_colorerror_(T, values)
 end
 
 _rem(x,::Type{T}) where {T<:Normed} = x % T

--- a/src/types.jl
+++ b/src/types.jl
@@ -558,13 +558,20 @@ eltype_default(::Type{C}) where {C<:AbstractGray } = N0f8
 eltype_default(::Type{C}) where {C<:Color  } = Float32
 eltype_default(::Type{P}) where {P<:Colorant        } = eltype_default(color_type(P))
 
-@inline function promote_eltype(::Type{C}, vals...) where C<:Colorant
-    _promote_eltype(eltype_default(C), promote_type(map(typeof, vals)...))
-end
-_promote_eltype(::Type{Tdef}, ::Type{T}) where {Tdef<:AbstractFloat, T<:AbstractFloat} = T
-_promote_eltype(::Type{Tdef}, ::Type{T}) where {Tdef<:FixedPoint, T<:Fractional} = T
-_promote_eltype(::Type{Tdef}, ::Type{T}) where {Tdef, T} = Tdef
+# Upper bound on element type for each color type
+eltype_ub(::Type{P}) where {P<:Colorant        } = eltype_ub(eltype_default(P))
+eltype_ub(::Type{T}) where {T<:FixedPoint   } = Fractional
+eltype_ub(::Type{T}) where {T<:AbstractFloat} = AbstractFloat
 
+@inline promote_eltype(::Type{C}, vals...) where {C<:Colorant} = _promote_eltype(eltype_ub(C), eltype_default(C), promote_type(map(typeof, vals)...))
+_promote_eltype(::Type{AbstractFloat}, ::Type{Tdef}, ::Type{T}) where {Tdef,T<:AbstractFloat} = T
+_promote_eltype(::Type{AbstractFloat}, ::Type{Tdef}, ::Type{T}) where {Tdef,T<:Real} = Tdef
+_promote_eltype(::Type{Fractional}, ::Type{Tdef}, ::Type{T}) where {Tdef,T<:Fractional} = T
+_promote_eltype(::Type{Fractional}, ::Type{Tdef}, ::Type{T}) where {Tdef,T<:Real} = Tdef
+
+ctypes = union(setdiff(parametric3, [XRGB,RGBX]), [Gray])
+
+# the arg list for C below should be identical to ctypes above.
 for (C, acol, cola) in [(DIN99d, :ADIN99d, :DIN99dA),
                         (DIN99o, :ADIN99o, :DIN99oA),
                         (DIN99, :ADIN99, :DIN99A),
@@ -586,8 +593,8 @@ for (C, acol, cola) in [(DIN99d, :ADIN99d, :DIN99dA),
     fn  = Expr(:tuple, fieldnames(C)...)
     cfn = Expr(:tuple, colorfields(C)...)
     elty = eltype_default(C)
-    ub   = elty <: FixedPoint ? Fractional : AbstractFloat
-    Csym = nameof(C)
+    ub   = eltype_ub(C)
+    Csym = nameof(Base.unwrap_unionall(C))
     @eval @make_constructors $Csym $fn $elty
     @eval @make_alpha $Csym $acol $cola $fn $cfn $ub $elty
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -16,17 +16,6 @@ grayscale) with no transparency.
 abstract type Color{T, N} <: Colorant{T,N} end
 
 """
-`AbstractGray{T}` is an abstract supertype for gray types which corresponds to
-real numbers, where `0` means black and `1` means white.
-
-!!! compat "ColorTypes v0.12"
-    Prior to ColorTypes v0.12, `AbstractGray{T}` was the alias for `Color{T,1}`;
-    after ColorTypes v0.12, `Color{T,1}` does not necessarily correspond to the
-    black-gray-white colors.
-"""
-abstract type AbstractGray{T} <: Color{T,1} end
-
-"""
 `AbstractRGB{T}` is an abstract supertype for red/green/blue color types that
 can be constructed as `C(r, g, b)` and for which the elements can be
 extracted as `red(c)`, `green(c)`, `blue(c)`. You should *not* make
@@ -76,6 +65,7 @@ alpha channel comes last in the internal storage order.
 abstract type ColorAlpha{C<:Color,T,N} <: TransparentColor{C,T,N} end
 
 # These are types we'll dispatch on.
+AbstractGray{T}                    = Color{T,1}
 Color3{T}                          = Color{T,3}
 TransparentGray{C<:AbstractGray,T} = TransparentColor{C,T,2}
 Transparent3{C<:Color3,T}          = TransparentColor{C,T,4}

--- a/src/types.jl
+++ b/src/types.jl
@@ -519,7 +519,7 @@ macro make_alpha(C, acol, cola, fields, constrfields, ub, elty)
             $acol{T}(p...)
         end
         function $acol($(constrfields...), alpha::Real)
-            p = promote($(constrfields...), gray(alpha))
+            p = promote($(constrfields...), alpha)
             T = typeof(p[1])
             $acol{T}(p...)
         end
@@ -536,7 +536,7 @@ macro make_alpha(C, acol, cola, fields, constrfields, ub, elty)
             $cola{T}(p...)
         end
         function $cola($(constrfields...), alpha::Real)
-            p = promote($(constrfields...), gray(alpha))
+            p = promote($(constrfields...), alpha)
             T = typeof(p[1])
             $cola{T}(p...)
         end
@@ -544,7 +544,7 @@ macro make_alpha(C, acol, cola, fields, constrfields, ub, elty)
         $cola() = $cola{$elty}($(zfields...))
         $cola($convqualifier) = convert($cola, x)
         $cola{T}(x) where T = convert($cola{T}, x)
-    end)
+end)
 end
 
 eltype_default(::Type{C}) where {C<:AbstractRGB  } = N0f8

--- a/src/types.jl
+++ b/src/types.jl
@@ -173,7 +173,7 @@ RGBX(r::T, g::T, b::T) where {T<:Fractional} = RGBX{T}(r, g, b)
 
 "`HSV` is the Hue-Saturation-Value colorspace."
 struct HSV{T<:AbstractFloat} <: Color{T,3}
-    h::T # Hue in [0,360]
+    h::T # Hue in [0,360)
     s::T # Saturation in [0,1]
     v::T # Value in [0,1]
 end
@@ -183,16 +183,16 @@ const HSB = HSV
 
 "`HSL` is the Hue-Saturation-Lightness colorspace."
 struct HSL{T<:AbstractFloat} <: Color{T,3}
-    h::T # Hue in [0,360]
+    h::T # Hue in [0,360)
     s::T # Saturation in [0,1]
     l::T # Lightness in [0,1]
 end
 
 "`HSI` is the Hue-Saturation-Intensity colorspace."
 struct HSI{T<:AbstractFloat} <: Color{T,3}
-    h::T # Hue in [0,360]
-    s::T # Saturation in [0,1]
-    i::T # Intensity in [0,1]
+    h::T
+    s::T
+    i::T
 end
 
 """
@@ -215,30 +215,30 @@ end
 
 "`Lab` is the CIELAB colorspace."
 struct Lab{T<:AbstractFloat} <: Color{T,3}
-    l::T # Lightness in [0,100]
+    l::T # Luminance in approximately [0,100]
     a::T # Red/Green
     b::T # Blue/Yellow
 end
 
 "`LCHab` is the Luminance-Chroma-Hue, Polar-Lab colorspace"
 struct LCHab{T<:AbstractFloat} <: Color{T,3}
-    l::T # Lightness in [0,100]
+    l::T # Luminance in [0,100]
     c::T # Chroma
-    h::T # Hue in [0,360]
+    h::T # Hue in [0,360)
 end
 
 "`Luv` is the CIELUV colorspace"
 struct Luv{T<:AbstractFloat} <: Color{T,3}
-    l::T # Lightness in [0,100]
+    l::T # Luminance
     u::T # Red/Green
     v::T # Blue/Yellow
 end
 
 "`LCHuv` is the Luminance-Chroma-Hue, Polar-Luv colorspace"
 struct LCHuv{T<:AbstractFloat} <: Color{T,3}
-    l::T # Lightness in [0,100]
+    l::T # Luminance
     c::T # Chroma
-    h::T # Hue in [0,360]
+    h::T # Hue
 end
 
 "`DIN99` is the (L99, a99, b99) adaptation of CIELAB"

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -846,14 +846,10 @@ end
     @test Gray24(1) == 1
     @test !(Gray24(1) == 0x00ffffff)
     @test !(AGray32(1,0) == 0x00ffffff)
-    @test reinterpret(UInt32,   RGB24(0x000001)) === 0x00ffffff
-    @test reinterpret(UInt32,  ARGB32(0x000000)) === 0xff000000
-    @test reinterpret(UInt32,  Gray24(0x000000)) === 0x00000000
-    @test reinterpret(UInt32, AGray32(0x000001)) === 0xffffffff
     ret = @test_throws ArgumentError RGB24(0x00ffffff)
     @test occursin("Use `reinterpret(RGB24, 0x00ffffff)`", ret.value.msg)
     ret = @test_throws ArgumentError ARGB32(0x00ffffff)
-    @test occursin("Use `reinterpret(ARGB32, 0x00ffffff)`", ret.value.msg)
+    @test_broken occursin("Use `reinterpret(ARGB32, 0x00ffffff)`", ret.value.msg)
     ret = @test_throws ArgumentError Gray24(0x00ffffff)
     @test occursin("Use `reinterpret(Gray24, 0x00ffffff)`", ret.value.msg)
     ret = @test_throws ArgumentError AGray32(0x00ffffff)
@@ -861,7 +857,7 @@ end
     c = 0x123456
     ret = @test_throws ArgumentError RGB24(c >> 16 & 0xFF, c >> 8 & 0xFF, c & 0xFF)
     @test !occursin("Use `reinterpret(RGB24", ret.value.msg)
-    @test occursin("(0x00000012, 0x00000034, 0x00000056) are integers", ret.value.msg)
+    @test occursin("(0x00000012, 0x00000034, 0x00000056) do not lie", ret.value.msg)
     @test_throws ArgumentError RGB24[0x00000000,0x00808080]
     @test_throws ArgumentError RGB24[0x00000000,0x00808080,0x00ffffff]
     @test_throws ArgumentError RGB24[0x00000000,0x00808080,0x00ffffff,0x000000ff]

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -585,8 +585,8 @@ end
 
     @test convert(RGB, 0.6) === RGB(0.6, 0.6, 0.6)
     @test convert(BGR, 0.6N0f8) === BGR{N0f8}(0.6, 0.6, 0.6)
-    @test convert(ARGB, 0.6) === ARGB(0.6, 0.6, 0.6, 1)
-    @test convert(RGBA, 0.6N0f8) === RGBA{N0f8}(0.6, 0.6, 0.6, 1)
+    @test_broken convert(ARGB, 0.6) === ARGB(0.6, 0.6, 0.6, 1)
+    @test_broken convert(RGBA, 0.6N0f8) === RGBA{N0f8}(0.6, 0.6, 0.6, 1)
 
     @test_broken convert(ARGB, 0.6f0, 0.8f0) === ARGB{Float32}(0.6, 0.6, 0.6, 0.8)
     @test_broken convert(RGBA{Float32}, 0.6, 0.8) === RGBA{Float32}(0.6, 0.6, 0.6, 0.8)

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -571,10 +571,10 @@ end
 
     @test_throws ColorTypeResolutionError convert(Colorant, 0.6)
     @test_throws ColorTypeResolutionError convert(Color, 0.6)
-    @test_throws MethodError convert(Color{N0f8,1}, 0.6)
+    @test_throws ColorTypeResolutionError convert(Color{N0f8,1}, 0.6)
 
-    @test convert(GrayA, 0.6, 0.8) === GrayA{Float64}(0.6, 0.8)
-    @test convert(AGray, 0, 1) === AGray{N0f8}(0, 1)
+    @test_throws MethodError convert(GrayA, 0.6, 0.8)
+    @test_throws MethodError convert(AGray, 0, 1)
 
     @test convert(Gray, 2.0) === Gray{Float64}(2.0)
     @test_throws ArgumentError convert(Gray, 2)
@@ -588,8 +588,8 @@ end
     @test convert(ARGB, 0.6) === ARGB(0.6, 0.6, 0.6, 1)
     @test convert(RGBA, 0.6N0f8) === RGBA{N0f8}(0.6, 0.6, 0.6, 1)
 
-    @test convert(ARGB, 0.6f0, 0.8f0) === ARGB{Float32}(0.6, 0.6, 0.6, 0.8)
-    @test convert(RGBA{Float32}, 0.6, 0.8) === RGBA{Float32}(0.6, 0.6, 0.6, 0.8)
+    @test_broken convert(ARGB, 0.6f0, 0.8f0) === ARGB{Float32}(0.6, 0.6, 0.6, 0.8)
+    @test_broken convert(RGBA{Float32}, 0.6, 0.8) === RGBA{Float32}(0.6, 0.6, 0.6, 0.8)
 
 end
 

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -3,9 +3,6 @@ using ColorTypes.FixedPointNumbers
 using Test
 using ColorTypes: ColorTypeResolutionError
 
-@isdefined(CustomTypes) || include("customtypes.jl")
-using .CustomTypes
-
 @testset "rgb promotions" begin
     @test promote( RGB{N0f8}(0.2,0.3,0.4),  RGB(0.3,0.8,0.1)) === ( RGB{Float64}(0.2N0f8,0.3N0f8,0.4N0f8),  RGB{Float64}(0.3,0.8,0.1))
     @test promote( RGB{N0f8}(0.2,0.3,0.4), RGBA(0.3,0.8,0.1)) === (RGBA{Float64}(0.2N0f8,0.3N0f8,0.4N0f8), RGBA{Float64}(0.3,0.8,0.1))
@@ -665,24 +662,6 @@ end
         @test convert(C, HSV{Float64}(100,0.4,0.6)) === C{Float64}(100,0.4,0.6,1)
         @test convert(C, HSV{Float32}(100,0.4,0.6), 0.2) === C{Float32}(100,0.4,0.6,0.2)
     end
-end
-
-@testset "conversions in the same color space" begin
-    @test convert(Cyanotype{Float32}, Cyanotype{Float64}(0.8)) === Cyanotype{Float32}(0.8)
-
-    @test convert(C2, C2{Float64}(0.4,0.6)) === C2{Float64}(0.4,0.6)
-    @test convert(C2{Float32}, C2{Float64}(0.4,0.6)) === C2{Float32}(0.4,0.6)
-    @test convert(C2, C2A{Float64}(0.4,0.6,0.5)) === C2{Float64}(0.4,0.6)
-    @test convert(C2A, C2A{Float32}(0.4,0.6,0.5)) === C2A{Float32}(0.4,0.6,0.5)
-    @test convert(C2A, C2{Float64}(0.4,0.6)) === C2A{Float64}(0.4,0.6,1.0)
-    @test convert(C2A, C2{Float32}(0.4,0.6), 0.25) === C2A{Float32}(0.4,0.6,0.25)
-
-    @test convert(CMYK, CMYK{Float64}(0.2,0.4,0.6,0.8)) === CMYK{Float64}(0.2,0.4,0.6,0.8)
-    @test convert(CMYK{Float32}, CMYK{Float64}(0.2,0.4,0.6,0.8)) === CMYK{Float32}(0.2,0.4,0.6,0.8)
-    @test convert(CMYK, ACMYK{Float64}(0.2,0.4,0.6,0.8,0.5)) === CMYK{Float64}(0.2,0.4,0.6,0.8)
-    @test convert(ACMYK, ACMYK{Float32}(0.2,0.4,0.6,0.8,0.5)) === ACMYK{Float32}(0.2,0.4,0.6,0.8,0.5)
-    @test convert(ACMYK, CMYK{Float64}(0.2,0.4,0.6,0.8)) === ACMYK{Float64}(0.2,0.4,0.6,0.8,1.0)
-    @test convert(ACMYK, CMYK{Float32}(0.2,0.4,0.6,0.8), 0.25) === ACMYK{Float32}(0.2,0.4,0.6,0.8,0.25)
 end
 
 @testset "conversions from gray to rgb" begin

--- a/test/customtypes.jl
+++ b/test/customtypes.jl
@@ -39,6 +39,8 @@ struct AC4{T <: Real} <: AlphaColor{C4{T},T,5}
 end
 ColorTypes.alphacolor(::Type{<:C4}) = AC4
 ColorTypes.eltype_default(::Type{<:AC4}) = Int16
+# TODO: The following should be generated automatically
+AC4{T}(c1, c2, c3, c4, alpha=1) where {T} = AC4{T}(T(c1), T(c2), T(c3), T(c4), T(alpha))
 
 struct StrangeGray{Something,T <: Integer} <: AbstractGray{Normed{T}}
     val::T
@@ -52,7 +54,6 @@ ColorTypes.gray(g::StrangeGray{X,T}) where {X, T} = reinterpret(Normed{T,sizeof(
 # non-gray color with a single component
 struct Cyanotype{T <: Real} <: Color{T,1}
    value::T
-   Cyanotype{T}(value::T) where {T} = new{T}(value)
 end
 
 function Base.convert(::Type{Cout}, c::C) where {Cout <: AbstractRGB, T, C <: Cyanotype{T}}
@@ -105,7 +106,8 @@ struct ACMYK{T <: Fractional} <: AlphaColor{CMYK{T},T,5}
     k::T
     ACMYK{T}(c::T, m::T, y::T, k::T, alpha::T=oneunit(T)) where {T} = new{T}(alpha, c, m, y, k)
 end
-ColorTypes.alphacolor(::Type{<:CMYK}) = ACMYK
 # TODO: The following should be generated automatically
+ACMYK{T}(c, m, y, k, alpha=1) where {T} = ACMYK{T}(T(c), T(m), T(y), T(k), T(alpha))
+ACMYK(c::T, m::T, y::T, k::T, alpha::T=oneunit(T)) where {T} = ACMYK{T}(c, m, y, k, alpha)
 ACMYK{T}(col::CMYK{T}, alpha::T=oneunit(T)) where {T} = ACMYK{T}(col.c, col.m, col.y, col.k, alpha)
 end # module

--- a/test/customtypes.jl
+++ b/test/customtypes.jl
@@ -6,7 +6,6 @@ using ColorTypes.FixedPointNumbers
 
 export C2, C2A, C4, AC4
 export StrangeGray, Cyanotype
-export RGBA32
 export AnaglyphColor, CMYK, ACMYK
 
 struct C2{T <: Real} <: Color{T,2}
@@ -62,20 +61,6 @@ function Base.convert(::Type{Cout}, c::C) where {Cout <: AbstractRGB, T, C <: Cy
     b = 0.88 - 0.5 * c.value^2
     Cout(T(r), T(g), T(b))
 end
-
-# non-parametric color
-struct RGBA32 <: AbstractRGBA{RGB24, N0f8}
-    color::UInt32
-    RGBA32(c::UInt32, ::Type{Val{true}}) = new(c)
-end
-function RGBA32(r, g, b, alpha=1N0f8)
-    u32 = reinterpret(UInt32, ARGB32(r, g, b, alpha))
-    RGBA32((u32 << 0x8) | (u32 >> 0x18), Val{true})
-end
-ColorTypes.red(  c::RGBA32) = reinterpret(N0f8, (c.color >> 0x18) % UInt8)
-ColorTypes.green(c::RGBA32) = reinterpret(N0f8, (c.color >> 0x10) % UInt8)
-ColorTypes.blue( c::RGBA32) = reinterpret(N0f8, (c.color >> 0x08) % UInt8)
-ColorTypes.alpha(c::RGBA32) = reinterpret(N0f8, c.color % UInt8)
 
 # minimal type for testing 2-component color
 struct AnaglyphColor{T} <: Color{T,2} # not `TransparentGray`

--- a/test/error_hints.jl
+++ b/test/error_hints.jl
@@ -15,6 +15,21 @@ macro except_str(expr, err_type)
 end
 
 @testset "error hints" begin
+    @testset "ones" begin
+        for T in (RGB, RGB{N0f8})
+            err_str = @except_str one(T) MethodError
+            @test occursin(r"MethodError: no method matching one\(::Type\{RGB.*\}", err_str)
+            @test occursin("You may need to `using ColorVectorSpace`.", err_str)
+
+            err_str = @except_str one(T(1, 1, 1)) MethodError
+            @test occursin(r"MethodError: no method matching one\(::RGB\{.*\}", err_str)
+            @test occursin("You may need to `using ColorVectorSpace`.", err_str)
+
+            err_str = @except_str ones(T) MethodError
+            @test occursin(r"MethodError: no method matching one\(::Type\{RGB.*\}", err_str)
+            @test occursin("You may need to `using ColorVectorSpace`.", err_str)
+        end
+    end
     @testset "Math" begin
         gray = Gray(0.8)
         rgb = RGB{Float32}(1, 0, 0)

--- a/test/operations.jl
+++ b/test/operations.jl
@@ -150,7 +150,8 @@ end
             BGR{Float16}, ABGR{N0f32}, BGRA{N2f14},
             HSV{Float32}, HSL{Float64}, ALab{Float32}, LCHabA{Float16},
             Gray, AGray, GrayA,
-            unique(ColorTypes.parametric3)...,
+            RGB, ARGB, RGBA, BGR, ABGR, BGRA, XRGB, RGBX,
+            HSV, HSL, Lab, LCHab, YIQ,
             AHSV, HSLA)
         CC = isconcretetype(C) ? C : C{Float64}
         c = rand(C)
@@ -183,10 +184,9 @@ end
     a = rand!(Array{RGB}(undef, 3, 5))
     @test a isa Matrix{RGB}
     @test typeof(a[1,1]) === RGB{Float64}
-    # issue #125
-    @test all_in_range(LCHab(50, 10, 359))
-    @test all_in_range(YIQ(0.5, 0.59, 0.0))
-    @test !all_in_range(YIQ(0.5, 0.0, -0.53))
+    @test_broken all_in_range(LCHab(50, 10, 359))
+    @test_broken all_in_range(YIQ(0.5, 0.59, 0.0))
+    @test_broken !all_in_range(YIQ(0.5, 0.0, -0.53))
 end
 
 @testset "mapc" begin

--- a/test/operations.jl
+++ b/test/operations.jl
@@ -39,8 +39,6 @@ end
     for C in unique(vcat(Cp3, coloralpha.(Cp3), alphacolor.(Cp3)))
         @test C{Float64}(1,0,0) == C{Float32}(1,0,0)
         @test C{Float32}(1,0,0) != C{Float32}(1,0,0.1)
-        @test isequal(C{Float64}(1,0,0), C{Float32}(1,0,0))
-        @test !isequal(C{Float32}(1,0,0), C{Float32}(1,0,0.1))
     end
 
     for (a, b) in ((Gray(1.0), Gray(1)),
@@ -51,7 +49,6 @@ end
         local a, b
         @test a !== b
         @test a == b
-        @test isequal(a, b)
         @test hash(a) == hash(b)
     end
     for (a, b) in ((RGB(1, 0.5, 0), RGBA(1, 0.5, 0, 0.9)),
@@ -60,16 +57,7 @@ end
                    (Lab(70, 0, 60), LCHab(70, 60, 90)))
         local a, b
         @test a != b
-        @test !isequal(a, b)
         @test hash(a) != hash(b)
-    end
-    for (a, b) in ((RGB(1.0, 0.5, NaN), RGB(1.0, 0.5, NaN)),
-                   (Gray(NaN32), Gray(NaN)),
-                   (Gray(NaN), NaN))
-        @test a != b
-        @test b != a
-        @test isequal(a, b)
-        @test isequal(b, a)
     end
     # It's not obvious whether we want these to compare as equal, but
     # whatever happens, you want hashing and equality-testing to yield the

--- a/test/operations.jl
+++ b/test/operations.jl
@@ -260,14 +260,6 @@ end
     @test @inferred(reducec(&, true, true))
     @test !(@inferred(reducec(&, false, true)))
     @test !(@inferred(reducec(&, true, false)))
-
-    @test @inferred(reducec(+, Gray(0.3), init=0.5)) === 0.5 + 0.3
-    @test @inferred(reducec(+, AGray{N0f8}(0.3, 0.8))) === 0.3N0f8 + 0.8N0f8 # overflow
-    @test @inferred(reducec(*, RGB(0.3, 0.8, 0.5), init=0.5)) === ((0.5 * 0.3) * 0.8) * 0.5
-    @test @inferred(reducec(*, RGBA{N0f8}(0.3, 0.8, 0.5, 0.7))) === ((0.3N0f8 * 0.8N0f8) * 0.5N0f8) * 0.7N0f8
-
-    @test @inferred(reducec(max, 0.3, init=0.5)) === 0.5
-    @test @inferred(reducec(min, 0.3)) === 0.3
 end
 
 @testset "mapreducec" begin
@@ -291,14 +283,6 @@ end
     @test !(@inferred(mapreducec(x->!x, &, false, true)))
     @test @inferred(mapreducec(x->!x, &, true, false))
     @test !@inferred(mapreducec(x->!x, &, false, false))
-
-    @test @inferred(mapreducec(x->x^2, max, Gray(0.3), init=0.01)) === 0.3^2
-    @test @inferred(mapreducec(x->x^2, max, AGray{N0f8}(0.3, 0.8))) === N0f8(0.8)^2
-    @test @inferred(mapreducec(x->x^2, min, RGB(0.3, 0.8, 0.5), init=0.2)) === 0.3^2
-    @test @inferred(mapreducec(x->x^2, min, RGBA{N0f8}(0.3, 0.8, 0.5, 0.7))) === N0f8(0.3)^2
-
-    @test @inferred(mapreducec(x->x^2, +, 0.3, init=0.5)) === 0.5 + 0.3^2
-    @test @inferred(mapreducec(x->x^2, *, 0.3)) === 0.3^2
 end
 
 @testset "ones/zeros" begin

--- a/test/operations.jl
+++ b/test/operations.jl
@@ -6,34 +6,6 @@ using Test
 @isdefined(CustomTypes) || include("customtypes.jl")
 using .CustomTypes
 
-@testset "iterators" begin
-    @testset "ComponentIterator" begin
-        argb_comps = ColorTypes.comps(ARGB(1.0f0, 0.5f0, 0.0f0))
-        @test Iterators.IteratorSize(typeof(argb_comps)) === Iterators.HasLength()
-        @test Iterators.IteratorEltype(typeof(argb_comps)) === Iterators.HasEltype()
-        @test length(argb_comps) == 4
-        @test eltype(typeof(argb_comps)) === Float32
-        @test axes(argb_comps) === (Base.OneTo(4),)
-        @test ndims(typeof(argb_comps)) == 1
-        a = []
-        for v in argb_comps
-            push!(a, v)
-        end
-        @test all(a .=== (1.0f0, 0.5f0, 0.0f0, 1.0f0))
-        @test argb_comps[3] === 0.0f0
-        @test_throws BoundsError argb_comps[5]
-        @test_throws MethodError argb_comps[4] = 0.0f0 # read-only
-        @test argb_comps[2:2:4] === (0.5f0, 1.0f0)
-        @test argb_comps[:] === argb_comps
-        @test firstindex(argb_comps) == 1
-        @test lastindex(argb_comps) == 4
-        @test Base.BroadcastStyle(typeof(argb_comps)) === Base.Broadcast.Style{Tuple}()
-        @test argb_comps .* 0.5 === (0.5, 0.25, 0.0, 0.5)
-        @test argb_comps .+ (1:4) == Float32[2.0f0, 2.5f0, 3.0f0, 5.0f0]
-        @test argb_comps ./ (1, 2, 3, 4) === (1.0f0, 0.25f0, 0.0f0, 0.25f0)
-    end
-end
-
 @testset "comparisons" begin
     Cp3 = ColorTypes.parametric3
     for C in unique(vcat(Cp3, coloralpha.(Cp3), alphacolor.(Cp3)))

--- a/test/operations.jl
+++ b/test/operations.jl
@@ -252,29 +252,3 @@ end
     @test @inferred(mapreducec(x->!x, &, true, false))
     @test !@inferred(mapreducec(x->!x, &, false, false))
 end
-
-@testset "ones/zeros" begin
-    for C in (Gray, Gray{N0f8}, GrayA{Float32}, Gray24, AGray32,
-              RGB, RGB{N0f8}, RGBA{Float32}, RGB24, ARGB32)
-        for f in (ones, zeros)
-            if f === ones && C <: TransparentColor
-                @test_broken f(C, 3, 5) # issue #162
-                continue
-            end
-            mat = @inferred(f(C, 3, 5))
-            # note that the return type of `ones(RGB)` is `Array{RGB}`, not `Array{RGB{N0f8}}`
-            @test typeof(mat) === Matrix{C}
-            @test size(mat) == (3, 5)
-            @test mat[2, 3] === (f === ones ? oneunit(C) : zero(C))
-        end
-    end
-    @test_throws ColorTypes.ColorTypeResolutionError ones(HSV{Float32}, 3, 5)
-    # Although `XYZ` and `LMS` have the definition of `oneunit`,
-    # it is generally not equivalent to `Gray(1)`.
-    @test_throws ColorTypes.ColorTypeResolutionError ones(XYZ, 3, 5)
-    @test_throws ColorTypes.ColorTypeResolutionError ones(LMS{Float64}, 3, 5)
-
-    @test zeros(HSV{Float32}, 3, 5)[2, 3] === zero(HSV{Float32})
-    @test zeros(XYZ, 3, 5)[2, 3] === zero(XYZ)
-    @test zeros(LMS{Float64}, 3, 5)[2, 3] === zero(LMS{Float64})
-end

--- a/test/operations.jl
+++ b/test/operations.jl
@@ -133,12 +133,6 @@ end
     @test_throws MethodError GrayA(0.8, 0.4) <= GrayA(0.9, 0.4)
     @test_throws MethodError GrayA(0.9, 0.4) > GrayA(0.8, 0.4)
     @test_throws MethodError GrayA(0.9, 0.4) >= GrayA(0.8, 0.4)
-
-    # 1-component color but not a gray
-    @test_throws MethodError Cyanotype{Float32}(0.8) < Cyanotype{Float32}(0.9)
-    @test_throws MethodError isless(Cyanotype{Float32}(0.8), Cyanotype{Float32}(0.9))
-    @test_throws MethodError Cyanotype{Float64}(0.8) < Gray(0.9)
-    @test_throws MethodError Cyanotype{Float64}(0.8) < 0.9
 end
 
 @testset "rand" begin

--- a/test/operations.jl
+++ b/test/operations.jl
@@ -140,8 +140,7 @@ end
         all(((f, gmin, gmax),) -> gmin <= getfield(c, f) <= gmax,
             zip(ColorTypes.colorfields(C), gamutmin(C), gamutmax(C)))
     end
-    eltypes = (N0f8, N2f6, N0f16, N2f14, N0f32, N2f30, Q3f12,
-               Float16, Float32, Float64)
+    eltypes = (N0f8, N2f6, N0f16, N2f14, N0f32, N2f30, Float16, Float32, Float64)
     @testset "rand($C)" for C in (
             (Gray{T} for T in eltypes)...,
             (RGB{T} for T in eltypes)...,
@@ -153,6 +152,10 @@ end
             RGB, ARGB, RGBA, BGR, ABGR, BGRA, XRGB, RGBX,
             HSV, HSL, Lab, LCHab, YIQ,
             AHSV, HSLA)
+        if C <: Transparent3 && !(C <: TransparentRGB)
+            @test_broken rand(C)
+            continue
+        end
         CC = isconcretetype(C) ? C : C{Float64}
         c = rand(C)
         @test c isa CC
@@ -165,25 +168,24 @@ end
         ap = a'
         @test ap[1, 1] == a[1, 1]
     end
-    @testset "rand($C)" for C in (Gray24, AGray32, RGB24, ARGB32)
+    @testset "rand($C)" for C in (Gray24, AGray32)
         c = rand(C)
-        @test c isa C
-        a = rand(C, 3, 5)
-        @test eltype(a) === C
-        @test size(a) == (3, 5)
-        C in (RGB24, ARGB32) && continue
         b = c.color
         @test b&0xff == (b>>8)&0xff == (b>>16)&0xff
+        @test c isa C
+        a = rand(C, 3, 5)
         for el in a
             b = el.color
             @test b&0xff == (b>>8)&0xff == (b>>16)&0xff
         end
+        @test eltype(a) === C
+        @test size(a) == (3, 5)
     end
-    @test rand(MersenneTwister(), RGB{N0f8}) isa RGB{N0f8}
-    @test rand!(Gray{Float32}[0.0, 0.1]) isa Vector{Gray{Float32}}
-    a = rand!(Array{RGB}(undef, 3, 5))
-    @test a isa Matrix{RGB}
-    @test typeof(a[1,1]) === RGB{Float64}
+    @test_broken rand(RGB24)
+    @test_broken rand(ARGB32)
+    @test_broken rand(MersenneTwister(), RGB{N0f8})
+    @test_broken rand!(Gray{Float32}[0.0, 0.1])
+    @test_broken all(all_in_range, rand(ARGB{Q3f12}, 10, 10))
     @test_broken all_in_range(LCHab(50, 10, 359))
     @test_broken all_in_range(YIQ(0.5, 0.59, 0.0))
     @test_broken !all_in_range(YIQ(0.5, 0.0, -0.53))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,8 +9,7 @@ doctest(ColorTypes, manual = false)
 
 # if the test below fails, please extend the list of types at the call to
 # make_alpha in types.jl (this is the price of making that list explicit)
-ctypes = union(setdiff(ColorTypes.parametric3, (XRGB, RGBX)), (Gray,))
-@test Set(ctypes) ==
+@test Set(ColorTypes.ctypes) ==
     Set([DIN99d, DIN99o, DIN99, HSI, HSL, HSV, LCHab, LCHuv,
          LMS, Lab, Luv, XYZ, YCbCr, YIQ, xyY, BGR, RGB, Gray])
 

--- a/test/show.jl
+++ b/test/show.jl
@@ -50,8 +50,6 @@ SP = VERSION >= v"1.6.0-DEV.771" ? " " : "" # JuliaLang/julia #37085
     show(iob, AGray32(0.8))
     @test String(take!(iob)) == "AGray32(0.8N0f8,1.0N0f8)"
 
-    show(iob, CustomTypes.RGBA32(0.4, 0.2, 0.8, 1.0))
-    @test String(take!(iob)) == "RGBA32(0.4N0f8,0.2N0f8,0.8N0f8,1.0N0f8)"
     show(iob, AnaglyphColor{Float32}(0.4, 0.2))
     @test String(take!(iob)) == "AnaglyphColor{Float32}(0.4f0,0.2f0)"
     show(iob, CMYK{Float64}(0.1, 0.2, 0.3, 0.4))

--- a/test/show.jl
+++ b/test/show.jl
@@ -9,89 +9,58 @@ SP = VERSION >= v"1.6.0-DEV.771" ? " " : "" # JuliaLang/julia #37085
 
 @testset "single color" begin
     iob = IOBuffer()
-    show(iob, RGB{N0f8}(0, 1/3, 1))
-    @test String(take!(iob)) == "RGB{N0f8}(0.0, 0.333, 1.0)"
-    show(iob, RGB{N0f16}(0, 1/3, 1))
-    @test String(take!(iob)) == "RGB{N0f16}(0.0, 0.33333, 1.0)"
-    show(iob, RGB{Float64}(0, 1/3, 1))
-    @test String(take!(iob)) == "RGB{Float64}(0.0, 0.3333333333333333, 1.0)"
-    show(IOContext(iob, :compact => true), RGB{Float64}(0, 1/3, 1))
-    @test String(take!(iob)) == "RGB{Float64}(0.0, 0.333333, 1.0)"
-    show(iob, RGBA{N0f8}(0, 1/3, 1, 0.5))
-    @test String(take!(iob)) == "RGBA{N0f8}(0.0, 0.333, 1.0, 0.502)"
-    show(IOContext(iob, :compact => true), RGBA{N0f8}(0, 1/3, 1, 0.5))
-    @test String(take!(iob)) == "RGBA{N0f8}(0.0, 0.333, 1.0, 0.502)"
-    show(iob, ARGB{N0f8}(0, 1/3, 1, 0.5))
-    @test String(take!(iob)) == "ARGB{N0f8}(0.0, 0.333, 1.0, 0.502)"
-    show(IOContext(iob, :compact => true), ARGB{N0f8}(0, 1/3, 1, 0.5))
-    @test String(take!(iob)) == "ARGB{N0f8}(0.0, 0.333, 1.0, 0.502)"
+    cf  = RGB{Float32}(0.32218,0.14983,0.87819)
+    c   = convert(RGB{N0f8}, cf)
+    c16 = RGB{N0f16}(0.32218,0.14983,0.87819)
+    ca  = RGBA{N0f8}(0.32218,0.14983,0.87819,0.99241)
+    ac  = alphacolor(ca)
+
+    show(iob, c)
+    @test String(take!(iob)) == "RGB{N0f8}(0.322,0.149,0.878)"
+    show(iob, c16)
+    @test String(take!(iob)) == "RGB{N0f16}(0.32218,0.14983,0.87819)"
+    show(iob, cf)
+    @test String(take!(iob)) == "RGB{Float32}(0.32218f0,0.14983f0,0.87819f0)"
+    show(IOContext(iob, :compact => true), cf)
+    @test String(take!(iob)) == "RGB{Float32}(0.32218,0.14983,0.87819)"
+    show(iob, ca)
+    @test String(take!(iob)) == "RGBA{N0f8}(0.322,0.149,0.878,0.992)"
+    show(IOContext(iob, :compact => true), ca)
+    @test String(take!(iob)) == "RGBA{N0f8}(0.322,0.149,0.878,0.992)"
+    show(iob, ac)
+    @test String(take!(iob)) == "ARGB{N0f8}(0.322,0.149,0.878,0.992)"
+    show(IOContext(iob, :compact => true), ac)
+    @test String(take!(iob)) == "ARGB{N0f8}(0.322,0.149,0.878,0.992)"
 
     show(iob, RGB24(0.4,0.2,0.8))
-    @test String(take!(iob)) == "RGB24(0.4N0f8, 0.2N0f8, 0.8N0f8)"
+    @test String(take!(iob)) == "RGB24(0.4N0f8,0.2N0f8,0.8N0f8)"
     show(iob, ARGB32(0.4,0.2,0.8,1.0))
-    @test String(take!(iob)) == "ARGB32(0.4N0f8, 0.2N0f8, 0.8N0f8, 1.0N0f8)"
+    @test String(take!(iob)) == "ARGB32(0.4N0f8,0.2N0f8,0.8N0f8,1.0N0f8)"
     show(IOContext(iob, :compact => true), ARGB32(0.4,0.2,0.8,1.0))
-    @test String(take!(iob)) == "ARGB32(0.4, 0.2, 0.8, 1.0)"
+    @test String(take!(iob)) == "ARGB32(0.4,0.2,0.8,1.0)"
 
     show(iob, Gray(0.8))
     @test String(take!(iob)) == "Gray{Float64}(0.8)"
     show(iob, GrayA(0.8))
-    @test String(take!(iob)) == "GrayA{Float64}(0.8, 1.0)"
+    @test String(take!(iob)) == "GrayA{Float64}(0.8,1.0)"
     show(iob, AGray(0.8))
-    @test String(take!(iob)) == "AGray{Float64}(0.8, 1.0)"
-    show(iob, Gray{Bool}(1))
-    @test String(take!(iob)) == "Gray{Bool}(1)"
+    @test String(take!(iob)) == "AGray{Float64}(0.8,1.0)"
     show(iob, Gray24(0.4))
     @test String(take!(iob)) == "Gray24(0.4N0f8)"
     show(iob, AGray32(0.8))
-    @test String(take!(iob)) == "AGray32(0.8N0f8, 1.0N0f8)"
+    @test String(take!(iob)) == "AGray32(0.8N0f8,1.0N0f8)"
 
     show(iob, CustomTypes.RGBA32(0.4, 0.2, 0.8, 1.0))
-    @test String(take!(iob)) == "RGBA32(0.4N0f8, 0.2N0f8, 0.8N0f8, 1.0N0f8)"
+    @test String(take!(iob)) == "RGBA32(0.4N0f8,0.2N0f8,0.8N0f8,1.0N0f8)"
     show(iob, AnaglyphColor{Float32}(0.4, 0.2))
-    @test String(take!(iob)) == "AnaglyphColor{Float32}(0.4, 0.2)"
+    @test String(take!(iob)) == "AnaglyphColor{Float32}(0.4f0,0.2f0)"
     show(iob, CMYK{Float64}(0.1, 0.2, 0.3, 0.4))
-    @test String(take!(iob)) == "CMYK{Float64}(0.1, 0.2, 0.3, 0.4)"
+    @test String(take!(iob)) == "CMYK{Float64}(0.1,0.2,0.3,0.4)"
     show(iob, ACMYK{N0f8}(0.2, 0.4, 0.6, 0.8))
-    @test String(take!(iob)) == "ACMYK{N0f8}(0.2, 0.4, 0.6, 0.8, 1.0)"
+    @test String(take!(iob)) == "ACMYK{N0f8}(0.2,0.4,0.6,0.8,1.0)"
 end
 
-@testset "array element" begin
-    iob = IOBuffer()
-    rgbf64 = RGB{Float64}(0, 1/3, 1)
-    show(IOContext(iob, :typeinfo=>RGB{Float64}), rgbf64)
-    @test String(take!(iob)) == "RGB(0.0, 0.3333333333333333, 1.0)"
-    show(IOContext(iob, :typeinfo=>RGB{Float64}, :compact=>true), rgbf64)
-    @test String(take!(iob)) == "RGB(0.0, 0.333333, 1.0)"
-    show(IOContext(iob, :typeinfo=>RGB), rgbf64)
-    @test String(take!(iob)) == "RGB{Float64}(0.0, 0.3333333333333333, 1.0)"
-
-    argb32 = ARGB32(0.4,0.2,0.8,1.0)
-    show(IOContext(iob, :typeinfo=>ARGB32), argb32)
-    @test String(take!(iob)) == "ARGB32(0.4N0f8, 0.2N0f8, 0.8N0f8, 1.0N0f8)"
-    show(IOContext(iob, :typeinfo=>ARGB32, :compact=>true), argb32)
-    @test String(take!(iob)) == "ARGB32(0.4, 0.2, 0.8, 1.0)"
-    show(IOContext(iob, :typeinfo=>ARGB), argb32)
-    @test String(take!(iob)) == "ARGB32(0.4N0f8, 0.2N0f8, 0.8N0f8, 1.0N0f8)"
-
-    grayf64 = Gray{Float64}(1/3)
-    show(IOContext(iob, :typeinfo=>Gray{Float64}), grayf64)
-    @test String(take!(iob)) == "0.3333333333333333"
-    show(IOContext(iob, :typeinfo=>Gray{Float64}, :compact=>true), grayf64)
-    @test String(take!(iob)) == "0.333333"
-    show(IOContext(iob, :typeinfo=>Gray), grayf64)
-    @test String(take!(iob)) == "Gray{Float64}(0.3333333333333333)"
-
-    grayb = Gray{Bool}(1)
-    show(IOContext(iob, :typeinfo=>Gray{Bool}), grayb)
-    @test String(take!(iob)) == "1"
-    show(IOContext(iob, :typeinfo=>Gray{Bool}, :compact=>true), grayb)
-    @test String(take!(iob)) == "1"
-    show(IOContext(iob, :typeinfo=>Gray), grayb)
-    @test String(take!(iob)) == "Gray{Bool}(1)"
-end
-
-@testset "summary" begin
+@testset "collection of colors" begin
     iob = IOBuffer()
     summary(iob, Gray{N0f8}[0.2, 0.4, 0.6])
     vec_summary = String(take!(iob))
@@ -107,15 +76,15 @@ end
     avec_summary = String(take!(iob))
 
     if VERSION >= v"1.6.0-DEV.356"
-        @test vec_summary == "3-element Vector{Gray{N0f8}}"
-        @test mat_summary == "2×2 Matrix{RGB{Float64}}"
-        @test view_summary == "2×2 view(::Matrix{RGB{Float64}}, :, :) with eltype RGB{Float64}"
-        @test avec_summary == "2-element Vector{TransparentColor}"
+        @test_broken vec_summary == "3-element Vector{Gray{N0f8}}"
+        @test_broken mat_summary == "2×2 Matrix{RGB{Float64}}"
+        @test_broken view_summary == "2×2 view(::Matrix{RGB{Float64}}, :, :) with eltype RGB{Float64}"
+        @test_broken avec_summary == "2-element Vector{TransparentColor}"
     else
         @test vec_summary == "3-element Array{Gray{N0f8},1} with eltype Gray{Normed{UInt8,8}}"
-        @test mat_summary == "2×2 Array{RGB{Float64},2}"
+        @test mat_summary == "2×2 Array{RGB{Float64},2} with eltype RGB{Float64}"
         @test view_summary == "2×2 view(::Array{RGB{Float64},2}, :, :) with eltype RGB{Float64}"
-        @test avec_summary == "2-element Array{TransparentColor,1}"
+        @test avec_summary == "2-element Array{TransparentColor,1} with eltype TransparentColor"
     end
 end
 

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -632,37 +632,27 @@ end
     @test_throws MethodError ColorTypes.nan(Gray(1.0))
 end
 
-# see also ones/zeros test in "test/operations.jl"
 @testset "identities for Gray" begin
-    @test one(    Gray{N0f8}) === 1N0f8
     @test oneunit(Gray{N0f8}) === Gray{N0f8}(1)
     @test zero(   Gray{N0f8}) === Gray{N0f8}(0)
-    @test @inferred(one(    Gray)) === 1N0f8
     @test @inferred(oneunit(Gray)) === Gray{N0f8}(1)
     @test @inferred(zero(   Gray)) === Gray{N0f8}(0)
-    @test one(    Gray{Bool}) === true
     @test oneunit(Gray{Bool}) === Gray{Bool}(1)
     @test zero(   Gray{Bool}) === Gray{Bool}(0)
 
-    @test one(    AGray{N0f8}) === 1N0f8
     @test oneunit(AGray{N0f8}) === AGray{N0f8}(1, 1)
     @test zero(   AGray{N0f8}) === AGray{N0f8}(0, 0)
-    @test @inferred(one(    AGray)) === 1N0f8
     @test @inferred(oneunit(AGray)) === AGray{N0f8}(1, 1)
     @test @inferred(zero(   AGray)) === AGray{N0f8}(0, 0)
-    @test one(    GrayA{Float32}) === 1.0f0
     @test oneunit(GrayA{Float32}) === GrayA{Float32}(1, 1)
     @test zero(   GrayA{Float32}) === GrayA{Float32}(0, 0)
 
-    @test one(    Gray24) === 1N0f8
     @test oneunit(Gray24) === Gray24(1)
     @test zero(   Gray24) === Gray24(0)
-    @test one(   AGray32) === 1N0f8
     @test oneunit(AGray32) === AGray32(1, 1)
     @test zero(   AGray32) === AGray32(0, 0)
 
     g = Gray{Float32}(0.8)
-    @test one(    g) === 1.0f0
     @test oneunit(g) === Gray{Float32}(1)
     @test zero(   g) === Gray{Float32}(0)
 
@@ -670,70 +660,53 @@ end
 end
 
 @testset "identities for RGB" begin
-    @test one(    RGB{N0f8}) === 1N0f8
     @test oneunit(RGB{N0f8}) === RGB{N0f8}(1, 1, 1)
     @test zero(   RGB{N0f8}) === RGB{N0f8}(0, 0, 0)
-    @test @inferred(one(    RGB)) === 1N0f8
     @test @inferred(oneunit(RGB)) === RGB{N0f8}(1, 1, 1)
     @test @inferred(zero(   RGB)) === RGB{N0f8}(0, 0, 0)
 
-    @test one(    ARGB{N0f8}) === 1N0f8
     @test oneunit(ARGB{N0f8}) === ARGB{N0f8}(1, 1, 1, 1)
     @test zero(   ARGB{N0f8}) === ARGB{N0f8}(0, 0, 0, 0)
-    @test @inferred(one(    ARGB)) === 1N0f8
     @test @inferred(oneunit(ARGB)) === ARGB{N0f8}(1, 1, 1, 1)
     @test @inferred(zero(   ARGB)) === ARGB{N0f8}(0, 0, 0, 0)
-    @test one(    RGBA{Float32}) === 1.0f0
     @test oneunit(RGBA{Float32}) === RGBA{Float32}(1, 1, 1, 1)
     @test zero(   RGBA{Float32}) === RGBA{Float32}(0, 0, 0, 0)
 
-    @test one(    RGB24) === 1N0f8
     @test oneunit(RGB24) === RGB24(1, 1, 1)
     @test zero(   RGB24) === RGB24(0, 0, 0)
-    @test one(    ARGB32) === 1N0f8
     @test oneunit(ARGB32) === ARGB32(1, 1, 1, 1)
     @test zero(   ARGB32) === ARGB32(0, 0, 0, 0)
 
     c = RGB{Float32}(0.4, 0.5, 0.6)
-    @test one(    c) === 1.0f0
     @test oneunit(c) === RGB{Float32}(1, 1, 1)
     @test zero(   c) === RGB{Float32}(0, 0, 0)
 end
 
 @testset "identities for other colors" begin
-    @test one(    XYZ{Float16}) === Float16(1)
     @test oneunit(XYZ{Float16}) === XYZ{Float16}(1, 1, 1)
     @test zero(   XYZ{Float16}) === XYZ{Float16}(0, 0, 0)
 
-    @test @inferred(one(    LMS)) === 1.0f0
     @test @inferred(oneunit(LMS)) === LMS{Float32}(1, 1, 1)
     @test @inferred(zero(   LMS)) === LMS{Float32}(0, 0, 0)
 
-    @test one( HSV{Float32}) === 1.0f0
-    @test_throws ArgumentError oneunit(HSV{Float32})
+    @test_throws MethodError oneunit(HSV{Float32})
     @test zero(HSV{Float32}) === HSV{Float32}(0, 0, 0)
 
-    @test one( ALab{Float16}) === Float16(1)
-    @test_throws ArgumentError oneunit(ALab{Float16})
+    @test_throws MethodError oneunit(ALab{Float16})
     @test zero(ALab{Float16}) === ALab{Float16}(0, 0, 0, 0)
 
-    @test one( LCHuvA{Float64}) === 1.0
-    @test_throws ArgumentError oneunit(LCHuvA{Float64})
+    @test_throws MethodError oneunit(LCHuvA{Float64})
     @test zero(LCHuvA{Float64}) === LCHuvA{Float64}(0, 0, 0, 0)
 
-    @test one( C2{Float64}) === 1.0
-    @test_throws ArgumentError oneunit(C2{Float64})
+    @test_throws MethodError oneunit(C2{Float64})
     @test zero(C2{Float64}) === C2{Float64}(0, 0)
 
-    @test one( C4{Float64}) === 1.0
-    @test_throws ArgumentError oneunit(C4{Float64})
+    @test_throws MethodError oneunit(C4{Float64})
     @test zero(C4{Float64}) === C4{Float64}(0, 0, 0, 0)
 
-    @test one(    CMYK{N0f8}) === 1N0f8
     @test oneunit(CMYK{N0f8}) === CMYK{N0f8}(1, 1, 1, 1)
     @test zero(   CMYK{N0f8}) === CMYK{N0f8}(0, 0, 0, 0)
 
-    @test one(    ACMYK{N0f8}) === 1N0f8
     @test oneunit(ACMYK{N0f8}) === ACMYK{N0f8}(1, 1, 1, 1, 1)
     @test zero(   ACMYK{N0f8}) === ACMYK{N0f8}(0, 0, 0, 0, 0)
 end

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -62,8 +62,8 @@ end
     @test alpha(HSV{Float16}(100, 0.4, 0.6)) === Float16(1.0)
     @test alpha(HSVA(100, 0.4, 0.6, 0.8)) === 0.8
     @test alpha(AHSV{Float32}(100, 0.4, 0.6, 0.8)) === 0.8f0
-    @test alpha(0)     === N0f8(1)
-    @test alpha(0.0f0) === 1.0f0
+    @test_broken alpha(0) === N0f8(1)
+    @test_broken alpha(0.0f0) === 1.0f0
 end
 
 @testset "gray" begin
@@ -76,12 +76,11 @@ end
     @test gray(Gray{Bool}(0)) === false
 
     @testset "gray for Real" begin
-        @test gray(1)       === N0f8(1)
-        @test gray(0.8)     === 0.8
+        @test gray(1) === 1 # TODO: change it to return `N0f8(1)`
+        @test gray(0.8) === 0.8
         @test gray(0.8N0f8) === 0.8N0f8
-        @test gray(true)    === true
-        @test gray(false)   === false
-        @test gray(1//2)    === 1/2   # depends on https://github.com/JuliaMath/FixedPointNumbers.jl/pull/177
+        @test gray(true) === true
+        @test gray(false) === false
     end
     @test_throws MethodError gray(HSVA(100, 0.4, 0.6, 0.8))
     @test_throws MethodError gray(Cyanotype{Float32}(0.8)) # 1-component color but not a gray

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -44,13 +44,6 @@ using .CustomTypes
         @test green(argb32) === 0.5N0f8
         @test blue(argb32)  === 0.0N0f8
     end
-    @testset "accessors for custom RGBA" begin
-        rgba32 = CustomTypes.RGBA32(1, 0.5, 0, 0.8)
-        @test red(rgba32)   === 1.0N0f8
-        @test green(rgba32) === 0.5N0f8
-        @test blue(rgba32)  === 0.0N0f8
-        @test alpha(rgba32) === 0.8N0f8
-    end
 
     @test_throws MethodError red(HSV(100, 0.6, 0.4))
 end
@@ -152,11 +145,6 @@ end
     @test comp5(ac4) === 0.5f0
     ct = Cyanotype{Float32}(0.8) # 1-component color but not a gray
     @test_broken comp1(ct) === 0.8f0
-    rgba32 = CustomTypes.RGBA32(1, 0.5, 0, 0.8)
-    @test comp1(rgba32) === 1N0f8
-    @test comp2(rgba32) === 0.5N0f8
-    @test comp3(rgba32) === 0N0f8
-    @test comp4(rgba32) === 0.8N0f8
 end
 
 @testset "color" begin

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -152,7 +152,7 @@ end
     @test comp4(ac4) === 0.4f0
     @test comp5(ac4) === 0.5f0
     ct = Cyanotype{Float32}(0.8) # 1-component color but not a gray
-    @test comp1(ct) === 0.8f0
+    @test_broken comp1(ct) === 0.8f0
     rgba32 = CustomTypes.RGBA32(1, 0.5, 0, 0.8)
     @test comp1(rgba32) === 1N0f8
     @test comp2(rgba32) === 0.5N0f8

--- a/test/types.jl
+++ b/test/types.jl
@@ -145,8 +145,8 @@ end
                 @test C{N0f16}(val1,val2,val1,0.8) === C(0.2N0f16,0.6N0f16,0.2N0f16,0.8N0f16)
             end
             # 1-arg constructor
-            @test C(val1) === C{typeof(val1)}(0.2,0.2,0.2,1)
-            @test C{N0f8}(val1) === C{N0f8}(0.2,0.2,0.2,1)
+            @test_broken C(val1) === C{typeof(val1)}(0.2,0.2,0.2,1)
+            @test_broken C{N0f8}(val1) === C{N0f8}(0.2,0.2,0.2,1)
         end
 
         @test_throws ArgumentError C(2,1,0) # integers
@@ -161,7 +161,6 @@ end
             @test isa(C(val,val,val), C)
             @test isa(C(val,val,val,0.8), C)
             @test isa(C(val,val,val,val), C) # no exception thrown
-            @test alpha(C(val)) === oneunit(val)
         end
     end
 end
@@ -266,8 +265,14 @@ end
         @test GrayA{N0f16}(val) === GrayA{N0f16}(0.2, 1)
         @test AGray32(val) === AGray32(0.2, 1)
         @test AGray32(val, 0.8) === AGray32(0.2, 0.8)
-        @test @inferred(AGray(val, 1)) === AGray{T}(0.2, 1)
-        @test @inferred(GrayA(val, 0)) === GrayA{T}(0.2, 0)
+        if val isa FixedPoint
+            @test AGray(val, 1) === AGray{Float32}(0.2, 1) # inconsistent eltype
+            @test_broken @inferred(AGray(val, 1)) === AGray{T}(0.2, 1)
+            @test_broken @inferred(GrayA(val, 0)) === GrayA{T}(0.2, 0)
+        else
+            @test @inferred(AGray(val, 1)) === AGray{T}(0.2, 1)
+            @test @inferred(GrayA(val, 0)) === GrayA{T}(0.2, 0)
+        end
         Ta = val isa AbstractGray ? T : Float64
         if val isa Gray24
             @test_broken @inferred(AGray(val, 0.8)) === AGray{Ta}(val, 0.8)


### PR DESCRIPTION
This is a patch release to "revert" the breaking change introduced in ColorTypes v0.11.1

After this, we can choose to tag a new minor release v0.12.0 for the breaking changes or wait until we're ready.

fixes #273 