### PR TITLE
ColorTypes v0.11.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ColorTypes"
 uuid = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
-version = "0.11.0"
+version = "0.11.2"
 
 [deps]
 FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"


### PR DESCRIPTION
Instead of reverting the commits in master branch (#274), this PR simply bump a patch version in `release-0.11` branch.