### PR TITLE
Preemptively fix tests that are about to break

### DIFF
--- a/test/error_hints.jl
+++ b/test/error_hints.jl
@@ -19,11 +19,11 @@ end
         gray = Gray(0.8)
         rgb = RGB{Float32}(1, 0, 0)
         err_str = @except_str gray + rgb MethodError
-        @test occursin("no method matching +(::Gray{Float64}, ::RGB{Float32})", err_str)
+        @test occursin("no method matching for call to +(::Gray{Float64}, ::RGB{Float32})", err_str)
         @test occursin("Math on colors is deliberately undefined in ColorTypes, but see the ColorVectorSpace package", err_str)
 
         err_str = @except_str gray * rgb MethodError
-        @test occursin("no method matching *(::Gray{Float64}, ::RGB{Float32})", err_str)
+        @test occursin("no method matching for call to *(::Gray{Float64}, ::RGB{Float32})", err_str)
         @test occursin("Math on colors is deliberately undefined in ColorTypes, but see the ColorVectorSpace package", err_str)
         @test occursin("You may also need `⋅`, `⊙`, or `⊗`.", err_str)
 


### PR DESCRIPTION
Apply these changes if https://github.com/JuliaLang/julia/pull/47369 gets merged.

The error message for MethodError currently applies to both calls to functions and `invoke()`, but did not specify which the error came from. Fixing this will break some tests, hence this PR.