### PR TITLE
remove tests that check that Base does not have certain features

### DIFF
--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -852,9 +852,6 @@ end
     @test reinterpret(UInt32, reinterpret(Gray24, 0xdc00ff12)) === 0xdc00ff12
 
     @test reinterpret(AGray32, 0xab121212) === AGray32(0.071, 0.671)
-
-    @test_throws ErrorException reinterpret(UInt32, ARGB{N0f8}(1, 0, 0))
-    @test_throws ErrorException reinterpret(ARGB{N0f8}, 0x12345678)
 end
 
 ### Prevent ambiguous definitions


### PR DESCRIPTION
Tests like this that check that certain features in Base do not exist are kind of pointless. They start failing once Base implements does features and the only thing to do is to remove the tests. In 1.10 this does not error so the tests fail.