### PR TITLE
Support conversion to a StyledStrings.SimpleColor

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,8 +6,15 @@ version = "0.12.0-dev"
 FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
+[weakdeps]
+StyledStrings = "f489334b-da3d-4c2e-b8f0-e476e12c162b"
+
+[extensions]
+StyledStringsExt = "StyledStrings"
+
 [compat]
 FixedPointNumbers = "0.5, 0.6, 0.7, 0.8"
+StyledStrings = "1"
 julia = "1"
 
 [extras]

--- a/ext/StyledStringsExt.jl
+++ b/ext/StyledStringsExt.jl
@@ -1,0 +1,14 @@
+module StyledStringsExt
+
+using ColorTypes
+import StyledStrings: SimpleColor
+
+function Base.convert(::Type{SimpleColor}, c::Colorant)
+    rgb = convert(RGB24, c)
+    r = reinterpret(red(rgb))
+    g = reinterpret(green(rgb))
+    b = reinterpret(blue(rgb))
+    SimpleColor((; r, g, b))
+end
+
+end


### PR DESCRIPTION
This enables easy interoperability with the Face constructor of StyledStrings.

With this, it's easy to do fun things like:
![image](https://github.com/JuliaGraphics/ColorTypes.jl/assets/20903656/b722eef3-08c2-44b5-b6ec-54a800290b4c)
