### PR TITLE
Mention YUV

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ end
 
 ### Y'CbCr
 
-A color-encoding format common in video and digital photography.
+A color-encoding format common in video and digital photography (also known as Y'UV or simply YUV).
 
 ```julia
 struct YCbCr{T} <: Color{T,3}


### PR DESCRIPTION
Added a mention of how YCbCr is a synonym to YUV. This allows people find the right encoding when searching for "yuv".