### PR TITLE
Update macOS test targets

### DIFF
--- a/.github/workflows/UnitTest.yml
+++ b/.github/workflows/UnitTest.yml
@@ -32,13 +32,19 @@ jobs:
         os:
           - ubuntu-latest
           - windows-latest
-          - macos-latest
+          - macos-13
         arch:
           - x64
         include:
           - os: ubuntu-latest
             version: '1'
             arch: x86
+          - os: macos-latest
+            version: '1'
+            arch: aarch64
+          - os: macos-latest
+            version: 'nightly'
+            arch: aarch64
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2


### PR DESCRIPTION
https://github.com/JuliaGraphics/ColorTypes.jl/pull/305#issuecomment-2081372732

Considering the backport, it would have been nice if this had been done with PR #301, but the timing was not clearly announced, so there was no choice.