### PR TITLE
Remove redundant pre-register StyledStrings compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,13 +14,13 @@ StyledStringsExt = "StyledStrings"
 
 [compat]
 FixedPointNumbers = "0.5, 0.6, 0.7, 0.8"
-# StyledStrings = "1" # FIXME: workaround for unregistered StyledStrings
+StyledStrings = "1"
 julia = "1"
 
 [extras]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f" # FIXME: workaround for unregistered StyledStrings
+StyledStrings = "f489334b-da3d-4c2e-b8f0-e476e12c162b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Documenter", "Pkg", "Test"]
+test = ["Documenter", "StyledStrings", "Test"]

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,4 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f" # FIXME: workaround for unregistered StyledStrings
+StyledStrings = "f489334b-da3d-4c2e-b8f0-e476e12c162b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,14 +1,3 @@
-
-# FIXME: Once StyledStrings v1 is registered, remove the following and the `Pkg` dependency
-if isdefined(Base, :get_extension)
-    import Pkg
-    if VERSION < v"1.11"
-        Pkg.add(url="https://github.com/JuliaLang/StyledStrings.jl", rev="julia1-compat")
-    else
-        Pkg.add("StyledStrings")
-    end
-end
-
 using ColorTypes
 using ColorTypes.FixedPointNumbers
 using Test
@@ -21,12 +10,8 @@ doctest(ColorTypes, manual = false)
 @testset "StyledStringsExt" begin
     if isdefined(Base, :get_extension)
         import StyledStrings
-        try
-            simplecolor = convert(StyledStrings.SimpleColor, ARGB(1, 0.6, 0, 0.4))
-            @test simplecolor === StyledStrings.SimpleColor(0xff, 0x99, 0x00)
-        catch
-            @test_broken convert(StyledStrings.SimpleColor, ARGB(1, 0.6, 0, 0.4))
-        end
+        simplecolor = convert(StyledStrings.SimpleColor, ARGB(1, 0.6, 0, 0.4))
+        @test simplecolor === StyledStrings.SimpleColor(0xff, 0x99, 0x00)
         @test_throws Exception convert(StyledStrings.SimpleColor, HSV(0, 0, 0))
     end
 end


### PR DESCRIPTION
Now that StyledStrings is registered, we can do away with this code (and also include StyledStrings support in a release, which would be nice).