### PR TITLE
Remove deprecated bindings in ColorTypes.jl

### DIFF
--- a/src/ColorTypes.jl
+++ b/src/ColorTypes.jl
@@ -49,8 +49,9 @@ include("show.jl")
 include("operations.jl")
 include("error_hints.jl")
 
-Base.@deprecate_binding RGB1 XRGB
-Base.@deprecate_binding RGB4 RGBX
+# As discussed in https://github.com/JuliaIO/ImageMagick.jl/issues/235
+#Base.@deprecate_binding RGB1 XRGB
+#Base.@deprecate_binding RGB4 RGBX
 
 """
 ColorTypes summary:


### PR DESCRIPTION
This should hopefully help remove warnings across the ecosystem. Discussion in https://github.com/JuliaIO/ImageMagick.jl/issues/235

This should lead to a bump in the version since it could be breaking.

cc @dgleich @ararslan 