### PR TITLE
explicitly qualify `Tuple` while adding method

### DIFF
--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -133,4 +133,4 @@ coloralpha(c::C) where {C<:TransparentColor} = coloralpha(base_color_type(C))(co
 coloralpha(c::C,a) where {C<:TransparentColor} = coloralpha(base_color_type(C))(color(c), a)
 
 # Tuple
-Tuple(c::Colorant{T, N}) where {T, N} = (comps(c)...,)::NTuple{N, T}
+Base.Tuple(c::Colorant{T, N}) where {T, N} = (comps(c)...,)::NTuple{N, T}


### PR DESCRIPTION
Prevent name ambiguity, adapt to changes in nightly Julia, preventing a warning during precompilation.

See:
* https://github.com/JuliaLang/julia/issues/25744
* https://github.com/JuliaLang/julia/issues/57290
* https://github.com/JuliaLang/julia/pull/57311