### PR TITLE
Fix warning when precompiling on Julia nightly

### DIFF
--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -133,4 +133,4 @@ coloralpha(c::C) where {C<:TransparentColor} = coloralpha(base_color_type(C))(co
 coloralpha(c::C,a) where {C<:TransparentColor} = coloralpha(base_color_type(C))(color(c), a)
 
 # Tuple
-Tuple(c::Colorant{T, N}) where {T, N} = (comps(c)...,)::NTuple{N, T}
+Base.Tuple(c::Colorant{T, N}) where {T, N} = (comps(c)...,)::NTuple{N, T}


### PR DESCRIPTION
It seems that Julia nightly desires all method definitions of names that have not explicitly been imported to be qualified (with e.g. `$module.$name`.