### PR TITLE
Qualify Tuple in method overload

### DIFF
--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -133,4 +133,4 @@ coloralpha(c::C) where {C<:TransparentColor} = coloralpha(base_color_type(C))(co
 coloralpha(c::C,a) where {C<:TransparentColor} = coloralpha(base_color_type(C))(color(c), a)
 
 # Tuple
-Tuple(c::Colorant{T, N}) where {T, N} = (comps(c)...,)::NTuple{N, T}
+Base.Tuple(c::Colorant{T, N}) where {T, N} = (comps(c)...,)::NTuple{N, T}


### PR DESCRIPTION
This removes the [following warning](https://github.com/JuliaDebug/Cthulhu.jl/actions/runs/14084243275/job/39444048842?pr=630#step:7:150) on 1.12+:

```
  1 dependency had output during precompilation:
┌ ColorTypes
│  WARNING: Constructor for type "Tuple" was extended in `ColorTypes` without explicit qualification or import.
│    NOTE: Assumed "Tuple" refers to `Base.Tuple`. This behavior is deprecated and may differ in future versions.`
│    NOTE: This behavior may have differed in Julia versions prior to 1.12.
│    Hint: If you intended to create a new generic function of the same name, use `function Tuple end`.
│    Hint: To silence the warning, qualify `Tuple` as `Base.Tuple` in the method signature or explicitly `import Base: Tuple`.
└  
```

which, as indicated, should be avoided in favor of an explicit overload.