### PR TITLE
Fix GPU kernel compilation by replacing @pure with @generated functions

### DIFF
--- a/src/ColorTypes.jl
+++ b/src/ColorTypes.jl
@@ -2,7 +2,17 @@ module ColorTypes
 
 using FixedPointNumbers
 import FixedPointNumbers: floattype
-using Base: @pure
+@static if VERSION >= v"1.8"
+    using Base: @assume_effects
+    macro pure_or_foldable(ex)
+        esc(:(@assume_effects :foldable $ex))
+    end
+else
+    using Base: @pure
+    macro pure_or_foldable(ex)
+        esc(:(@pure $ex))
+    end
+end
 
 const Fractional = Union{AbstractFloat, FixedPoint}
 

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -120,7 +120,7 @@ color(c::TransparentColorN{5,C}) where {C} = C(comp1(c), comp2(c), comp3(c), com
 # recurse up the type hierarchy until you get to Colorant{T,N} for
 # specific T,N.
 to_top(::Type{Colorant{T,N}}) where {T,N} = Colorant{T,N}
-@pure to_top(::Type{C}) where {C<:Colorant} = to_top(supertype(C))
+@pure_or_foldable to_top(::Type{C}) where {C<:Colorant} = to_top(supertype(C))
 
 to_top(c::Colorant) = to_top(typeof(c))
 
@@ -137,18 +137,28 @@ eltype(::Type{C}) where {C<:Colorant{T}} where {T} = T
 
 eltype(c::Colorant) = eltype(typeof(c))
 
-@pure function _parameter_upper_bound(t::UnionAll, idx)
+@pure_or_foldable function _parameter_upper_bound(t::UnionAll, idx)
     Base.rewrap_unionall((Base.unwrap_unionall(t)::DataType).parameters[idx], t)
 end
 
 # eltypes_supported(Colorant{T<:X}) -> X
-function eltypes_supported(::Type{C}) where {C<:Colorant}
+# Implementation functions for compile-time evaluation
+function _eltypes_supported_impl(::Type{C}, ::Type) where {C<:Colorant}
+    _parameter_upper_bound(C, 1)
+end
+function _eltypes_supported_impl(::Type{<:Colorant}, ::Type{C}) where {C<:Colorant}
+    _eltypes_supported_impl(C, supertype(C))
+end
+function _eltypes_supported_impl(::Type{C}) where {C<:Colorant}
     Cb = base_colorant_type(C)
     isconcretetype(C) && C === Cb && return eltype(C)
-    _eltypes_supported(Cb, supertype(Cb))
+    _eltypes_supported_impl(Cb, supertype(Cb))
 end
-@pure _eltypes_supported(::Type{<:Colorant}, ::Type{C}) where {C<:Colorant} = _eltypes_supported(C, supertype(C))
-_eltypes_supported(::Type{C}, ::Type) where {C<:Colorant} = _parameter_upper_bound(C, 1)
+
+@generated function eltypes_supported(::Type{C}) where {C<:Colorant}
+    result = _eltypes_supported_impl(C)
+    return :($result)
+end
 
 eltypes_supported(c::Colorant) = eltypes_supported(typeof(c))
 
@@ -157,7 +167,10 @@ eltypes_supported(c::Colorant) = eltypes_supported(typeof(c))
 
 Returns `true` if `T` is a valid numeric eltype for `C<:Colorant`.
 """
-issupported(::Type{C}, ::Type{T}) where {C<:Colorant,T} = T <: eltypes_supported(C)
+@generated function issupported(::Type{C}, ::Type{T}) where {C<:Colorant,T}
+    result = T <: _eltypes_supported_impl(C)
+    return :($result)
+end
 
 """
     CT = color_type(C::Type)
@@ -231,7 +244,7 @@ base_color_type(x::Union{Colorant,Number}) = base_color_type(typeof(x))
 base_colorant_type(::Type{C}) where {C<:Colorant} = isabstracttype(C) ? abstract_basetype(C) : basetype(C)
 base_colorant_type(::Type{<:Number}) = Gray
 
-@pure basetype(@nospecialize(C)) = Base.typename(C).wrapper
+@pure_or_foldable basetype(@nospecialize(C)) = Base.typename(C).wrapper
 
 abstract_basetype(::Type{<:AbstractRGB}) = AbstractRGB
 abstract_basetype(::Type{<:AbstractGray}) = AbstractGray
@@ -342,7 +355,7 @@ floattype(::Type{Gray24})  = Gray{floattype(N0f8)}
 floattype(::Type{ARGB32})  = ARGB{floattype(N0f8)}
 floattype(::Type{AGray32}) = AGray{floattype(N0f8)}
 
-@pure pureintersect(::Type{C1}, ::Type{C2}) where {C1,C2} = typeintersect(C1, C2)
+@pure_or_foldable pureintersect(::Type{C1}, ::Type{C2}) where {C1,C2} = typeintersect(C1, C2)
 
 """
     Calpha, Cbase, T = colorsplit(C)


### PR DESCRIPTION
## Summary

ColorTypes uses several `@pure`-annotated functions to perform compile-time
type computations (walking the type hierarchy, extracting parameter bounds,
checking element type support). This worked on Julia 1.9 with GPU compilers
(CUDA.jl, Metal.jl) because `@pure` allowed the compiler to constant-fold
these calls, eliminating all dynamic dispatch from the generated IR.

Starting around Julia 1.10, `@pure` was deprecated in favor of
`@assume_effects`. More critically, the GPU compiler infrastructure
(GPUCompiler.jl) disables semi-concrete interpretation to avoid issues
with method table overlays (JuliaLang/julia#47349). This means the
compiler can no longer fold away the recursive type-walking in
`_eltypes_supported` and the subtype check (`<:`) in `issupported`, leaving
dynamic dispatch calls (`jl_apply_generic`, `jl_f_issubtype`) in the LLVM IR.
Metal.jl rejects these as `InvalidIRError`:

- `unsupported dynamic function invocation (call to _eltypes_supported)`
- `unsupported call to an unknown function (call to jl_f_issubtype)`

See: https://github.com/JuliaGPU/Metal.jl/issues/613

## What was tried

**Attempted fix:** replacing `@pure` with `@assume_effects :foldable` on all five
annotated functions. This did **NOT** resolve the issue — the compiler still
failed to fold the recursive type-hierarchy walk during GPU compilation.

**Working fix:** convert `eltypes_supported` and `issupported` to `@generated`
functions. Generated functions execute their body during compilation and
return a quoted expression, guaranteeing the result is a compile-time
constant with zero runtime dispatch. The recursive implementation is
moved to `_eltypes_supported_impl` helper functions that are called inside
the `@generated` body. The remaining three `@pure` sites (`to_top`, `basetype`,
`pureintersect`, `_parameter_upper_bound`) are replaced with
`@assume_effects :foldable` as a modernization, though these are not on
the critical GPU code path.

## Test plan

- [x] Metal.jl MWE (`@metal kernel(MtlArray{RGB{Float32}}(undef, 1))`) runs without `InvalidIRError`
- [x] Full ColorTypes test suite passes (6226 tests, 0 failures)
- [ ] CUDA.jl code path calls the same ColorTypes functions — should be compatible but was not tested directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)